### PR TITLE
Add shared routes example

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "server-side-rendering/*",
     "dynamic-system-host/*",
     "shared-routing/*",
+    "shared-routes2/*",
     "typescript/*",
     "redux-reducer-injection/*"
   ],

--- a/shared-routes2/README.md
+++ b/shared-routes2/README.md
@@ -1,0 +1,13 @@
+# Basic One-Way Example
+
+This example demos a basic host application loading remote component.
+
+- `app1` is the host application.
+- `app2` standalone application which exposes `Button` component.
+
+# Running Demo
+
+Run `yarn start`. This will build and serve both `app1` and `app2` on ports 3001 and 3002 respectively.
+
+- [localhost:3001](http://localhost:3001/) (HOST)
+- [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)

--- a/shared-routes2/README.md
+++ b/shared-routes2/README.md
@@ -1,13 +1,14 @@
-# Basic One-Way Example
+# Shared Routing Example
 
-This example demos a basic host application loading remote component.
+This example demos two applications with their own sets of routes and deployments but a seamless experience for the user.
 
-- `app1` is the host application.
-- `app2` standalone application which exposes `Button` component.
+- `app1` contains the "Home Page" (/) route.
+- `app2` contains the "About Page" (/about) route.
+- `app1` also exposes `Navigation` component.
 
 # Running Demo
 
 Run `yarn start`. This will build and serve both `app1` and `app2` on ports 3001 and 3002 respectively.
 
-- [localhost:3001](http://localhost:3001/) (HOST)
-- [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
+- [localhost:3001](http://localhost:3001/)
+- [localhost:3002](http://localhost:3002/)

--- a/shared-routes2/app1/package.json
+++ b/shared-routes2/app1/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@shared-routes2/app1",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "^7.8.7",
+    "@babel/preset-react": "^7.8.3",
+    "babel-loader": "^8.0.6",
+    "html-webpack-plugin": "git://github.com/ScriptedAlchemy/html-webpack-plugin#master",
+    "serve": "^11.3.0",
+    "webpack": "git://github.com/webpack/webpack.git#dev-1",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.10.3"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "build": "webpack --mode production",
+    "serve": "serve dist -p 3001"
+  },
+  "dependencies": {
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0"
+  }
+}

--- a/shared-routes2/app1/package.json
+++ b/shared-routes2/app1/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "react": "^16.13.0",
-    "react-dom": "^16.13.0"
+    "react-dom": "^16.13.0",
+    "react-router-dom": "^5.1.2"
   }
 }

--- a/shared-routes2/app1/public/index.html
+++ b/shared-routes2/app1/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <script src="http://localhost:3002/remoteEntry.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/shared-routes2/app1/src/App.js
+++ b/shared-routes2/app1/src/App.js
@@ -1,0 +1,15 @@
+import React from "react";
+
+const RemoteButton = React.lazy(() => import("app2/Button"));
+
+const App = () => (
+  <div>
+    <h1>Basic Host-Remote</h1>
+    <h2>App 1</h2>
+    <React.Suspense fallback="Loading Button">
+      <RemoteButton />
+    </React.Suspense>
+  </div>
+);
+
+export default App;

--- a/shared-routes2/app1/src/App.js
+++ b/shared-routes2/app1/src/App.js
@@ -1,15 +1,29 @@
-import React from "react";
+import { HashRouter, Route, Switch } from "react-router-dom";
 
-const RemoteButton = React.lazy(() => import("app2/Button"));
+import Navigation from "./Navigation";
+import React from "react";
+import localRoutes from "./routes";
+import remoteRoutes from "app2/routes";
+
+const routes = [...localRoutes, ...remoteRoutes];
 
 const App = () => (
-  <div>
-    <h1>Basic Host-Remote</h1>
-    <h2>App 1</h2>
-    <React.Suspense fallback="Loading Button">
-      <RemoteButton />
-    </React.Suspense>
-  </div>
+  <HashRouter>
+    <div>
+      <h1>App 1</h1>
+      <Navigation />
+      <Switch>
+        {routes.map(route => (
+          <Route
+            key={route.path}
+            path={route.path}
+            component={route.component}
+            exact={route.exact}
+          />
+        ))}
+      </Switch>
+    </div>
+  </HashRouter>
 );
 
 export default App;

--- a/shared-routes2/app1/src/App.js
+++ b/shared-routes2/app1/src/App.js
@@ -12,16 +12,18 @@ const App = () => (
     <div>
       <h1>App 1</h1>
       <Navigation />
-      <Switch>
-        {routes.map(route => (
-          <Route
-            key={route.path}
-            path={route.path}
-            component={route.component}
-            exact={route.exact}
-          />
-        ))}
-      </Switch>
+      <React.Suspense fallback={<div>Loading...</div>}>
+        <Switch>
+          {routes.map(route => (
+            <Route
+              key={route.path}
+              path={route.path}
+              component={route.component}
+              exact={route.exact}
+            />
+          ))}
+        </Switch>
+      </React.Suspense>
     </div>
   </HashRouter>
 );

--- a/shared-routes2/app1/src/HomePage.js
+++ b/shared-routes2/app1/src/HomePage.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const HomePage = () => <h1>Home Page</h1>;
+
+export default HomePage;

--- a/shared-routes2/app1/src/HomePage.js
+++ b/shared-routes2/app1/src/HomePage.js
@@ -2,8 +2,7 @@ import React from "react";
 
 const style = {
   height: 400,
-  backgroundImage: "url(https://i.picsum.photos/id/324/1920/1080.jpg)",
-  backgroundSize: "cover",
+  backgroundColor: "#673ab7",
   color: "white",
   textShadow: "0 0 3px #000, 0 0 6px #000",
   padding: 12

--- a/shared-routes2/app1/src/HomePage.js
+++ b/shared-routes2/app1/src/HomePage.js
@@ -4,7 +4,6 @@ const style = {
   height: 400,
   backgroundColor: "#673ab7",
   color: "white",
-  textShadow: "0 0 3px #000, 0 0 6px #000",
   padding: 12
 };
 

--- a/shared-routes2/app1/src/HomePage.js
+++ b/shared-routes2/app1/src/HomePage.js
@@ -1,5 +1,22 @@
 import React from "react";
 
-const HomePage = () => <h1>Home Page</h1>;
+const style = {
+  height: 400,
+  backgroundImage: "url(https://i.picsum.photos/id/324/1920/1080.jpg)",
+  backgroundSize: "cover",
+  color: "white",
+  textShadow: "0 0 3px #000, 0 0 6px #000",
+  padding: 12
+};
+
+const HomePage = () => (
+  <div style={style}>
+    <h1>Home Page</h1>
+    <h2>Welcome to the future!</h2>
+    <p>
+      <em>a page being provided by App 1</em>
+    </p>
+  </div>
+);
 
 export default HomePage;

--- a/shared-routes2/app1/src/Navigation.js
+++ b/shared-routes2/app1/src/Navigation.js
@@ -1,0 +1,10 @@
+import { Link } from "react-router-dom";
+import React from "react";
+
+const Navigation = () => (
+  <div style={{ border: "1px solid #000" }}>
+    <Link to="/">Home</Link> - <Link to="/about">About</Link>
+  </div>
+);
+
+export default Navigation;

--- a/shared-routes2/app1/src/Navigation.js
+++ b/shared-routes2/app1/src/Navigation.js
@@ -1,8 +1,10 @@
 import { Link } from "react-router-dom";
 import React from "react";
 
+const style = { border: "1px solid #000", padding: 12 };
+
 const Navigation = () => (
-  <div style={{ border: "1px solid #000" }}>
+  <div style={style}>
     <Link to="/">Home</Link> - <Link to="/about">About</Link>
   </div>
 );

--- a/shared-routes2/app1/src/bootstrap.js
+++ b/shared-routes2/app1/src/bootstrap.js
@@ -1,0 +1,5 @@
+import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/shared-routes2/app1/src/index.js
+++ b/shared-routes2/app1/src/index.js
@@ -1,0 +1,1 @@
+import("./bootstrap");

--- a/shared-routes2/app1/src/routes.js
+++ b/shared-routes2/app1/src/routes.js
@@ -1,0 +1,6 @@
+const routes = [
+  {
+    path: "/home",
+    component: HomePage
+  }
+];

--- a/shared-routes2/app1/src/routes.js
+++ b/shared-routes2/app1/src/routes.js
@@ -1,4 +1,6 @@
-import HomePage from "./HomePage";
+import React from "react";
+
+const HomePage = React.lazy(() => import("./HomePage"));
 
 const routes = [
   {

--- a/shared-routes2/app1/src/routes.js
+++ b/shared-routes2/app1/src/routes.js
@@ -1,6 +1,11 @@
+import HomePage from "./HomePage";
+
 const routes = [
   {
-    path: "/home",
-    component: HomePage
+    path: "/",
+    component: HomePage,
+    exact: true
   }
 ];
+
+export default routes;

--- a/shared-routes2/app1/webpack.config.js
+++ b/shared-routes2/app1/webpack.config.js
@@ -28,8 +28,9 @@ module.exports = {
     new ModuleFederationPlugin({
       name: "app1",
       library: { type: "var", name: "app1" },
-      remotes: {
-        app2: "app2"
+      filename: "remoteEntry.js",
+      exposes: {
+        routes: "./src/routes"
       },
       shared: ["react", "react-dom"]
     }),

--- a/shared-routes2/app1/webpack.config.js
+++ b/shared-routes2/app1/webpack.config.js
@@ -1,0 +1,40 @@
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const path = require("path");
+
+module.exports = {
+  entry: "./src/index",
+  mode: "development",
+  devServer: {
+    contentBase: path.join(__dirname, "dist"),
+    port: 3001
+  },
+  output: {
+    publicPath: "http://localhost:3001/"
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        exclude: /node_modules/,
+        options: {
+          presets: ["@babel/preset-react"]
+        }
+      }
+    ]
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "app1",
+      library: { type: "var", name: "app1" },
+      remotes: {
+        app2: "app2"
+      },
+      shared: ["react", "react-dom"]
+    }),
+    new HtmlWebpackPlugin({
+      template: "./public/index.html"
+    })
+  ]
+};

--- a/shared-routes2/app1/webpack.config.js
+++ b/shared-routes2/app1/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = {
         app2: "app2"
       },
       exposes: {
+        Navigation: "./src/Navigation",
         routes: "./src/routes"
       },
       shared: ["react", "react-dom", "react-router-dom"]

--- a/shared-routes2/app1/webpack.config.js
+++ b/shared-routes2/app1/webpack.config.js
@@ -29,10 +29,13 @@ module.exports = {
       name: "app1",
       library: { type: "var", name: "app1" },
       filename: "remoteEntry.js",
+      remotes: {
+        app2: "app2"
+      },
       exposes: {
         routes: "./src/routes"
       },
-      shared: ["react", "react-dom"]
+      shared: ["react", "react-dom", "react-router-dom"]
     }),
     new HtmlWebpackPlugin({
       template: "./public/index.html"

--- a/shared-routes2/app2/package.json
+++ b/shared-routes2/app2/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@shared-routes2/app2",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "^7.8.7",
+    "@babel/preset-react": "^7.8.3",
+    "babel-loader": "^8.0.6",
+    "html-webpack-plugin": "git://github.com/ScriptedAlchemy/html-webpack-plugin#master",
+    "serve": "^11.3.0",
+    "webpack": "git://github.com/webpack/webpack.git#dev-1",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.10.3"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "build": "webpack --mode production",
+    "serve": "serve dist -p 3002"
+  },
+  "dependencies": {
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0"
+  }
+}

--- a/shared-routes2/app2/package.json
+++ b/shared-routes2/app2/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "react": "^16.13.0",
-    "react-dom": "^16.13.0"
+    "react-dom": "^16.13.0",
+    "react-router-dom": "^5.1.2"
   }
 }

--- a/shared-routes2/app2/public/index.html
+++ b/shared-routes2/app2/public/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/shared-routes2/app2/public/index.html
+++ b/shared-routes2/app2/public/index.html
@@ -1,4 +1,7 @@
 <html>
+  <head>
+    <script src="http://localhost:3001/remoteEntry.js"></script>
+  </head>
   <body>
     <div id="root"></div>
   </body>

--- a/shared-routes2/app2/src/AboutPage.js
+++ b/shared-routes2/app2/src/AboutPage.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const AboutPage = () => <h1>About Page</h1>;
+
+export default AboutPage;

--- a/shared-routes2/app2/src/AboutPage.js
+++ b/shared-routes2/app2/src/AboutPage.js
@@ -1,5 +1,22 @@
 import React from "react";
 
-const AboutPage = () => <h1>About Page</h1>;
+const style = {
+  height: 400,
+  backgroundImage: "url(https://i.picsum.photos/id/1025/1920/1080.jpg)",
+  backgroundSize: "cover",
+  color: "white",
+  textShadow: "0 0 3px #000, 0 0 6px #000",
+  padding: 12
+};
+
+const AboutPage = () => (
+  <div style={style}>
+    <h1>About Page</h1>
+    <h2>We love dogs!</h2>
+    <p>
+      <em>a page being provided by App 2</em>
+    </p>
+  </div>
+);
 
 export default AboutPage;

--- a/shared-routes2/app2/src/AboutPage.js
+++ b/shared-routes2/app2/src/AboutPage.js
@@ -2,8 +2,7 @@ import React from "react";
 
 const style = {
   height: 400,
-  backgroundImage: "url(https://i.picsum.photos/id/1025/1920/1080.jpg)",
-  backgroundSize: "cover",
+  backgroundColor: "#3f51b5",
   color: "white",
   textShadow: "0 0 3px #000, 0 0 6px #000",
   padding: 12

--- a/shared-routes2/app2/src/AboutPage.js
+++ b/shared-routes2/app2/src/AboutPage.js
@@ -4,7 +4,6 @@ const style = {
   height: 400,
   backgroundColor: "#3f51b5",
   color: "white",
-  textShadow: "0 0 3px #000, 0 0 6px #000",
   padding: 12
 };
 

--- a/shared-routes2/app2/src/AboutPage.js
+++ b/shared-routes2/app2/src/AboutPage.js
@@ -10,7 +10,6 @@ const style = {
 const AboutPage = () => (
   <div style={style}>
     <h1>About Page</h1>
-    <h2>We love dogs!</h2>
     <p>
       <em>a page being provided by App 2</em>
     </p>

--- a/shared-routes2/app2/src/App.js
+++ b/shared-routes2/app2/src/App.js
@@ -1,0 +1,12 @@
+import LocalButton from "./Button";
+import React from "react";
+
+const App = () => (
+  <div>
+    <h1>Basic Host-Remote</h1>
+    <h2>App 2</h2>
+    <LocalButton />
+  </div>
+);
+
+export default App;

--- a/shared-routes2/app2/src/App.js
+++ b/shared-routes2/app2/src/App.js
@@ -1,14 +1,19 @@
 import { HashRouter, Route, Switch } from "react-router-dom";
 
+import Navigation from "app1/Navigation";
 import React from "react";
 import localRoutes from "./routes";
+import remoteRoutes from "app1/routes";
+
+const routes = [...localRoutes, ...remoteRoutes];
 
 const App = () => (
   <HashRouter>
     <div>
       <h1>App 2</h1>
+      <Navigation />
       <Switch>
-        {localRoutes.map(route => (
+        {routes.map(route => (
           <Route
             key={route.path}
             path={route.path}

--- a/shared-routes2/app2/src/App.js
+++ b/shared-routes2/app2/src/App.js
@@ -1,12 +1,24 @@
-import LocalButton from "./Button";
+import { HashRouter, Route, Switch } from "react-router-dom";
+
 import React from "react";
+import localRoutes from "./routes";
 
 const App = () => (
-  <div>
-    <h1>Basic Host-Remote</h1>
-    <h2>App 2</h2>
-    <LocalButton />
-  </div>
+  <HashRouter>
+    <div>
+      <h1>App 2</h1>
+      <Switch>
+        {localRoutes.map(route => (
+          <Route
+            key={route.path}
+            path={route.path}
+            component={route.component}
+            exact={route.exact}
+          />
+        ))}
+      </Switch>
+    </div>
+  </HashRouter>
 );
 
 export default App;

--- a/shared-routes2/app2/src/App.js
+++ b/shared-routes2/app2/src/App.js
@@ -12,16 +12,18 @@ const App = () => (
     <div>
       <h1>App 2</h1>
       <Navigation />
-      <Switch>
-        {routes.map(route => (
-          <Route
-            key={route.path}
-            path={route.path}
-            component={route.component}
-            exact={route.exact}
-          />
-        ))}
-      </Switch>
+      <React.Suspense fallback={<div>Loading...</div>}>
+        <Switch>
+          {routes.map(route => (
+            <Route
+              key={route.path}
+              path={route.path}
+              component={route.component}
+              exact={route.exact}
+            />
+          ))}
+        </Switch>
+      </React.Suspense>
     </div>
   </HashRouter>
 );

--- a/shared-routes2/app2/src/Button.js
+++ b/shared-routes2/app2/src/Button.js
@@ -1,5 +1,0 @@
-import React from "react";
-
-const Button = () => <button>App 2 Button</button>;
-
-export default Button;

--- a/shared-routes2/app2/src/Button.js
+++ b/shared-routes2/app2/src/Button.js
@@ -1,0 +1,5 @@
+import React from "react";
+
+const Button = () => <button>App 2 Button</button>;
+
+export default Button;

--- a/shared-routes2/app2/src/bootstrap.js
+++ b/shared-routes2/app2/src/bootstrap.js
@@ -1,0 +1,5 @@
+import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/shared-routes2/app2/src/index.js
+++ b/shared-routes2/app2/src/index.js
@@ -1,0 +1,1 @@
+import("./bootstrap");

--- a/shared-routes2/app2/src/routes.js
+++ b/shared-routes2/app2/src/routes.js
@@ -1,4 +1,6 @@
-import AboutPage from "./AboutPage";
+import React from "react";
+
+const AboutPage = React.lazy(() => import("./AboutPage"));
 
 const routes = [
   {

--- a/shared-routes2/app2/src/routes.js
+++ b/shared-routes2/app2/src/routes.js
@@ -1,6 +1,10 @@
+import AboutPage from "./AboutPage";
+
 const routes = [
   {
     path: "/about",
     component: AboutPage
   }
 ];
+
+export default routes;

--- a/shared-routes2/app2/src/routes.js
+++ b/shared-routes2/app2/src/routes.js
@@ -1,0 +1,6 @@
+const routes = [
+  {
+    path: "/about",
+    component: AboutPage
+  }
+];

--- a/shared-routes2/app2/webpack.config.js
+++ b/shared-routes2/app2/webpack.config.js
@@ -30,7 +30,7 @@ module.exports = {
       library: { type: "var", name: "app2" },
       filename: "remoteEntry.js",
       exposes: {
-        Button: "./src/Button"
+        routes: "./src/routes"
       },
       shared: ["react", "react-dom"]
     }),

--- a/shared-routes2/app2/webpack.config.js
+++ b/shared-routes2/app2/webpack.config.js
@@ -1,0 +1,41 @@
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const path = require("path");
+
+module.exports = {
+  entry: "./src/index",
+  mode: "development",
+  devServer: {
+    contentBase: path.join(__dirname, "dist"),
+    port: 3002
+  },
+  output: {
+    publicPath: "http://localhost:3002/"
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        exclude: /node_modules/,
+        options: {
+          presets: ["@babel/preset-react"]
+        }
+      }
+    ]
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "app2",
+      library: { type: "var", name: "app2" },
+      filename: "remoteEntry.js",
+      exposes: {
+        Button: "./src/Button"
+      },
+      shared: ["react", "react-dom"]
+    }),
+    new HtmlWebpackPlugin({
+      template: "./public/index.html"
+    })
+  ]
+};

--- a/shared-routes2/app2/webpack.config.js
+++ b/shared-routes2/app2/webpack.config.js
@@ -29,10 +29,13 @@ module.exports = {
       name: "app2",
       library: { type: "var", name: "app2" },
       filename: "remoteEntry.js",
+      remotes: {
+        app1: "app1"
+      },
       exposes: {
         routes: "./src/routes"
       },
-      shared: ["react", "react-dom"]
+      shared: ["react", "react-dom", "react-router-dom"]
     }),
     new HtmlWebpackPlugin({
       template: "./public/index.html"

--- a/shared-routes2/package.json
+++ b/shared-routes2/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "lerna run --scope @shared-routes2/* --parallel start",
+    "build": "lerna run --scope @shared-routes2/* build",
+    "serve": "lerna run --scope @shared-routes2/* --parallel serve"
+  }
+}


### PR DESCRIPTION
Naming this example as `shared-routes2` for now. Likely will shift things around in the future.

app1 exposes:
- `routes` with `HomePage`
- `Navigation`

app2 exposes:
- `routes` with `AboutPage`

All routes are lazily loaded.

![Apr-13-2020 21-44-09](https://user-images.githubusercontent.com/7856703/79187269-b0236280-7dd0-11ea-9a77-73dd74cc5275.gif)

![image](https://user-images.githubusercontent.com/7856703/79187392-f37dd100-7dd0-11ea-8ab8-26a7c98285dc.png)

