### PR TITLE
Add version discrepancy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,6 @@ This repository is to showcase examples on Webpack 5's new Module Federation can
 - [ ] Non-UI Module
 - [x] Routing
 - [ ] Nested
-- [x] Version Discrepancy
+- [x] [Version Discrepancy](./version-discrepancy/README.md) &mdash; Federated apps depending on different versions of a dependency without side-effects.
 - [x] [TypeScript](./typescript/README.md) &mdash; Simple host/remote example using TypeScript.
 - [ ] NextJS

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "shared-routing/*",
     "shared-routes2/*",
     "typescript/*",
+    "version-discrepancy/*",
     "redux-reducer-injection/*"
   ],
   "devDependencies": {

--- a/version-discrepancy/README.md
+++ b/version-discrepancy/README.md
@@ -1,0 +1,13 @@
+# Version Discrepency Example
+
+This example demos two federated apps that use two different versions of lodash.
+
+- `app1` uses lodash@4.10.0.
+- `app2` uses lodash@4.11.0 and `lodash.nth`--a feature not available in lodash@4.10.0.
+
+# Running Demo
+
+Run `yarn start`. This will build and serve both `app1` and `app2` on ports 3001 and 3002 respectively.
+
+- [localhost:3001](http://localhost:3001/)
+- [localhost:3002](http://localhost:3002/)

--- a/version-discrepancy/app1/package.json
+++ b/version-discrepancy/app1/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@version-discrepancy/app1",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/preset-react": "^7.9.1",
+    "babel-loader": "^8.1.0",
+    "html-webpack-plugin": "git://github.com/ScriptedAlchemy/html-webpack-plugin#master",
+    "serve": "^11.3.0",
+    "webpack": "git://github.com/webpack/webpack.git#dev-1",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.10.3"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "build": "webpack --mode production",
+    "serve": "serve dist -p 3001"
+  },
+  "dependencies": {
+    "lodash": "4.10.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  }
+}

--- a/version-discrepancy/app1/public/index.html
+++ b/version-discrepancy/app1/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <script src="http://localhost:3002/remoteEntry.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/version-discrepancy/app1/src/App.js
+++ b/version-discrepancy/app1/src/App.js
@@ -1,0 +1,31 @@
+import { VERSION, nth } from "lodash";
+
+import React from "react";
+
+const RemoteExample = React.lazy(() => import("app2/Example"));
+
+const App = () => {
+  return (
+    <div>
+      <h1>App 1 Host</h1>
+      <p>Lodash v{VERSION}</p>
+      <p>
+        <code>
+          typeof lodash.nth
+          <br />
+          // => {typeof nth}
+        </code>
+        <br />
+        <br />
+        <em>
+          (<code>lodash.nth</code> not available until lodash@4.11)
+        </em>
+      </p>
+      <React.Suspense fallback="Loading Example">
+        <RemoteExample />
+      </React.Suspense>
+    </div>
+  );
+};
+
+export default App;

--- a/version-discrepancy/app1/src/bootstrap.js
+++ b/version-discrepancy/app1/src/bootstrap.js
@@ -1,0 +1,5 @@
+import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/version-discrepancy/app1/src/index.js
+++ b/version-discrepancy/app1/src/index.js
@@ -1,0 +1,1 @@
+import("./bootstrap");

--- a/version-discrepancy/app1/webpack.config.js
+++ b/version-discrepancy/app1/webpack.config.js
@@ -1,0 +1,43 @@
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const path = require("path");
+
+module.exports = {
+  entry: "./src/index",
+  mode: "development",
+  devServer: {
+    contentBase: path.join(__dirname, "dist"),
+    port: 3001,
+  },
+  output: {
+    publicPath: "http://localhost:3001/",
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        options: {
+          presets: ["@babel/preset-react"],
+        },
+      },
+    ],
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "app1",
+      library: { type: "var", name: "app1" },
+      remotes: {
+        app2: "app2",
+      },
+      shared: {
+        react: "react",
+        "react-dom": "react-dom",
+        [`lodash-${require("lodash").VERSION}`]: "lodash",
+      },
+    }),
+    new HtmlWebpackPlugin({
+      template: "./public/index.html",
+    }),
+  ],
+};

--- a/version-discrepancy/app2/package.json
+++ b/version-discrepancy/app2/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@version-discrepancy/app2",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/preset-react": "^7.9.1",
+    "babel-loader": "^8.1.0",
+    "html-webpack-plugin": "git://github.com/ScriptedAlchemy/html-webpack-plugin#master",
+    "serve": "^11.3.0",
+    "webpack": "git://github.com/webpack/webpack.git#dev-1",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.10.3"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "build": "webpack --mode production",
+    "serve": "serve dist -p 3002"
+  },
+  "dependencies": {
+    "lodash": "4.11.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  }
+}

--- a/version-discrepancy/app2/public/index.html
+++ b/version-discrepancy/app2/public/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/version-discrepancy/app2/src/App.js
+++ b/version-discrepancy/app2/src/App.js
@@ -1,0 +1,11 @@
+import LocalExample from "./Example";
+import React from "react";
+
+const App = () => (
+  <div>
+    <h1>App 2: Remote</h1>
+    <LocalExample />
+  </div>
+);
+
+export default App;

--- a/version-discrepancy/app2/src/Example.js
+++ b/version-discrepancy/app2/src/Example.js
@@ -1,0 +1,28 @@
+import { VERSION, nth } from "lodash";
+
+import React from "react";
+
+const Example = () => {
+  return (
+    <div style={{ border: "1px solid black", padding: 12 }}>
+      <h3>Remote Component</h3>
+      <p>Lodash v{VERSION}</p>
+      <p>
+        <code>
+          typeof lodash.nth
+          <br />
+          // => {typeof nth}
+        </code>
+      </p>
+      <p>
+        <code>
+          nth(['a', 'b'], -1)
+          <br />
+          // => "{nth(["a", "b"], -1)}"
+        </code>
+      </p>
+    </div>
+  );
+};
+
+export default Example;

--- a/version-discrepancy/app2/src/bootstrap.js
+++ b/version-discrepancy/app2/src/bootstrap.js
@@ -1,0 +1,5 @@
+import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/version-discrepancy/app2/src/index.js
+++ b/version-discrepancy/app2/src/index.js
@@ -1,0 +1,1 @@
+import("./bootstrap");

--- a/version-discrepancy/app2/webpack.config.js
+++ b/version-discrepancy/app2/webpack.config.js
@@ -1,0 +1,44 @@
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const path = require("path");
+
+module.exports = {
+  entry: "./src/index",
+  mode: "development",
+  devServer: {
+    contentBase: path.join(__dirname, "dist"),
+    port: 3002,
+  },
+  output: {
+    publicPath: "http://localhost:3002/",
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        options: {
+          presets: ["@babel/preset-react"],
+        },
+      },
+    ],
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "app2",
+      library: { type: "var", name: "app2" },
+      filename: "remoteEntry.js",
+      exposes: {
+        Example: "./src/Example",
+      },
+      shared: {
+        react: "react",
+        "react-dom": "react-dom",
+        [`lodash-${require("lodash").VERSION}`]: "lodash",
+      },
+    }),
+    new HtmlWebpackPlugin({
+      template: "./public/index.html",
+    }),
+  ],
+};

--- a/version-discrepancy/package.json
+++ b/version-discrepancy/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "lerna run --scope @version-discrepancy/* --parallel start",
+    "build": "lerna run --scope @version-discrepancy/* build",
+    "serve": "lerna run --scope @version-discrepancy/* --parallel serve"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,7 +43,7 @@
     invariant "^2.2.4"
     semver "^5.5.0"
 
-"@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.8.6":
+"@babel/core@^7.1.0", "@babel/core@^7.4.5", "@babel/core@^7.8.6", "@babel/core@^7.9.0":
   version "7.9.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
   integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
@@ -963,7 +963,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-react@^7.0.0":
+"@babel/preset-react@^7.0.0", "@babel/preset-react@^7.9.1":
   version "7.9.4"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.9.4.tgz#c6c97693ac65b6b9c0b4f25b948a8f665463014d"
   integrity sha512-AxylVB3FXeOTQXNXyiuAQJSvss62FEotbX2Pzx3K/7c+MKJMdSg6Ose6QYllkdCFA8EInCJVw7M/o5QbLuA4ZQ==
@@ -2990,6 +2990,17 @@ babel-loader@^8.0.6:
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
     pify "^4.0.1"
+
+babel-loader@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.1.0.tgz#c611d5112bd5209abe8b9fa84c3e4da25275f1c3"
+  integrity sha512-7q7nC1tYOrqvUrN3LQK4GwSk/TQorZSOlO9C+RZDZpODgyN4ZlCqE5q9cDsyWOliN+aU9B4JX01xK9eJXowJLw==
+  dependencies:
+    find-cache-dir "^2.1.0"
+    loader-utils "^1.4.0"
+    mkdirp "^0.5.3"
+    pify "^4.0.1"
+    schema-utils "^2.6.5"
 
 babel-plugin-dynamic-import-node@^2.3.0:
   version "2.3.0"
@@ -5529,7 +5540,7 @@ finalhandler@~1.1.2:
     statuses "~1.5.0"
     unpipe "~1.0.0"
 
-find-cache-dir@^2.0.0:
+find-cache-dir@^2.0.0, find-cache-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-2.1.0.tgz#8d0f94cd13fe43c6c7c261a0d86115ca918c05f7"
   integrity sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==
@@ -8061,6 +8072,16 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.10.0.tgz#3d8f3ac7a5a904fdb01e2cfe1401879bf9652c6a"
+  integrity sha1-PY86x6WpBP2wHiz+FAGHm/llLGo=
+
+lodash@4.11.0:
+  version "4.11.0"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.11.0.tgz#428f7172a5e9a82e9a459b543816489810ecb8af"
+  integrity sha1-Qo9xcqXpqC6aRZtUOBZImBDsuK8=
+
 lodash@4.17.14:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
@@ -8588,7 +8609,7 @@ mkdirp@*:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.3.tgz#4cf2e30ad45959dddea53ad97d518b6c8205e1ea"
   integrity sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g==
 
-"mkdirp@>=0.5 0", mkdirp@~0.5.1:
+"mkdirp@>=0.5 0", mkdirp@^0.5.3, mkdirp@~0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -10280,7 +10301,7 @@ react-dom@^16.13.0:
     prop-types "^15.6.2"
     scheduler "^0.19.0"
 
-react-dom@^16.8.6:
+react-dom@^16.13.1, react-dom@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.13.1.tgz#c1bd37331a0486c078ee54c4740720993b2e0e7f"
   integrity sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==
@@ -10446,7 +10467,7 @@ react@^16.13.0:
     object-assign "^4.1.1"
     prop-types "^15.6.2"
 
-react@^16.8.6:
+react@^16.13.1, react@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==


### PR DESCRIPTION
Add example on two different apps depending on different versions of lodash.

Copying example from https://github.com/mizx/module-federation-examples/tree/master/version-discrepancy

![image](https://user-images.githubusercontent.com/7856703/79419167-2065eb80-7f6b-11ea-8c0b-923acf6cae46.png)
