### PR TITLE
Add shared context example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository is to showcase examples on Webpack 5's new Module Federation can
 - [x] [Server-Side Rendering](./server-side-rendering/README.md) &mdash; App1 and App2 with SSR.
 - [x] [Multi UI Framework Federation](./comprehensive-demo/README.md) &mdash; Multiple Apps in different technologies federated.
 - [ ] Nested Interleaved Components
-- [x] Share State/Context Providers
+- [x] [Share Context Provider](./shared-context/README.md) &mdash; App1 and App2 with shared Context Provider.
 - [ ] Non-UI Module
 - [x] Routing
 - [ ] Nested

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "comprehensive-demo/*",
     "server-side-rendering/*",
     "dynamic-system-host/*",
+    "shared-context/*",
     "shared-routing/*",
     "shared-routes2/*",
     "typescript/*",

--- a/shared-context/README.md
+++ b/shared-context/README.md
@@ -1,0 +1,14 @@
+# Shared Context Example
+
+This example demos a host application wrapped in a ContextProvider and renders a remote component consuming the ContextProvider value.
+
+- `app1` is the host application and is wrapped with `NameContextProvider` with value of `"Billy"`.
+- `app2` standalone application which exposes `Welcome` component. `Welcome` renders `"Welcome, <name>"`, where name is the value provided from `NameContextProvider.
+- `shared-library` is a library that would be shared between `app1` and `app2`. This library contains `NameContextProvider` component.
+
+# Running Demo
+
+Run `yarn start`. This will build and serve both `app1` and `app2` on ports 3001 and 3002 respectively.
+
+- [localhost:3001](http://localhost:3001/)
+- [localhost:3002](http://localhost:3002/)

--- a/shared-context/app1/package.json
+++ b/shared-context/app1/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@shared-context/app1",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/preset-react": "^7.9.1",
+    "babel-loader": "^8.1.0",
+    "html-webpack-plugin": "git://github.com/ScriptedAlchemy/html-webpack-plugin#master",
+    "serve": "^11.3.0",
+    "webpack": "git://github.com/webpack/webpack.git#dev-1",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.10.3"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "build": "webpack --mode production",
+    "serve": "serve dist -p 3001"
+  },
+  "dependencies": {
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  }
+}

--- a/shared-context/app1/public/index.html
+++ b/shared-context/app1/public/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <script src="http://localhost:3002/remoteEntry.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/shared-context/app1/src/App.js
+++ b/shared-context/app1/src/App.js
@@ -1,0 +1,18 @@
+import { NameContextProvider } from "@shared-context/shared-library";
+import React from "react";
+
+const Welcome = React.lazy(() => import("app2/Welcome"));
+
+const App = () => (
+  <div>
+    <h1>Context Provider</h1>
+    <h2>App 1</h2>
+    <NameContextProvider.Provider value="Billy">
+      <React.Suspense fallback="Loading Name">
+        <Welcome />
+      </React.Suspense>
+    </NameContextProvider.Provider>
+  </div>
+);
+
+export default App;

--- a/shared-context/app1/src/bootstrap.js
+++ b/shared-context/app1/src/bootstrap.js
@@ -1,0 +1,5 @@
+import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/shared-context/app1/src/index.js
+++ b/shared-context/app1/src/index.js
@@ -1,0 +1,1 @@
+import("./bootstrap");

--- a/shared-context/app1/webpack.config.js
+++ b/shared-context/app1/webpack.config.js
@@ -1,0 +1,39 @@
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const path = require("path");
+
+module.exports = {
+  entry: "./src/index",
+  mode: "development",
+  devServer: {
+    contentBase: path.join(__dirname, "dist"),
+    port: 3001,
+  },
+  output: {
+    publicPath: "http://localhost:3001/",
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        options: {
+          presets: ["@babel/preset-react"],
+        },
+      },
+    ],
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "app1",
+      library: { type: "var", name: "app1" },
+      remotes: {
+        app2: "app2",
+      },
+      shared: ["react", "react-dom", "@shared-context/shared-library"],
+    }),
+    new HtmlWebpackPlugin({
+      template: "./public/index.html",
+    }),
+  ],
+};

--- a/shared-context/app2/package.json
+++ b/shared-context/app2/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@shared-context/app2",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "^7.9.0",
+    "@babel/preset-react": "^7.9.1",
+    "babel-loader": "^8.1.0",
+    "html-webpack-plugin": "git://github.com/ScriptedAlchemy/html-webpack-plugin#master",
+    "serve": "^11.3.0",
+    "webpack": "git://github.com/webpack/webpack.git#dev-1",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.10.3"
+  },
+  "scripts": {
+    "start": "webpack-dev-server",
+    "build": "webpack --mode production",
+    "serve": "serve dist -p 3002"
+  },
+  "dependencies": {
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
+  }
+}

--- a/shared-context/app2/public/index.html
+++ b/shared-context/app2/public/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/shared-context/app2/src/App.js
+++ b/shared-context/app2/src/App.js
@@ -1,0 +1,15 @@
+import { NameContextProvider } from "../../shared-library/src";
+import React from "react";
+import Welcome from "./Welcome";
+
+const App = () => (
+  <div>
+    <h1>Context Provider</h1>
+    <h2>App 2</h2>
+    <NameContextProvider.Provider value="Susan">
+      <Welcome />
+    </NameContextProvider.Provider>
+  </div>
+);
+
+export default App;

--- a/shared-context/app2/src/Welcome.js
+++ b/shared-context/app2/src/Welcome.js
@@ -1,0 +1,10 @@
+import { NameContextProvider } from "@shared-context/shared-library";
+import React from "react";
+
+const Welcome = () => {
+  const name = React.useContext(NameContextProvider);
+
+  return <p>Welcome, {name}</p>;
+};
+
+export default Welcome;

--- a/shared-context/app2/src/bootstrap.js
+++ b/shared-context/app2/src/bootstrap.js
@@ -1,0 +1,5 @@
+import App from "./App";
+import React from "react";
+import ReactDOM from "react-dom";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/shared-context/app2/src/index.js
+++ b/shared-context/app2/src/index.js
@@ -1,0 +1,1 @@
+import("./bootstrap");

--- a/shared-context/app2/webpack.config.js
+++ b/shared-context/app2/webpack.config.js
@@ -1,0 +1,40 @@
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPlugin");
+const path = require("path");
+
+module.exports = {
+  entry: "./src/index",
+  mode: "development",
+  devServer: {
+    contentBase: path.join(__dirname, "dist"),
+    port: 3002,
+  },
+  output: {
+    publicPath: "http://localhost:3002/",
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        options: {
+          presets: ["@babel/preset-react"],
+        },
+      },
+    ],
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "app2",
+      library: { type: "var", name: "app2" },
+      filename: "remoteEntry.js",
+      exposes: {
+        Welcome: "./src/Welcome",
+      },
+      shared: ["react", "react-dom", "@shared-context/shared-library"],
+    }),
+    new HtmlWebpackPlugin({
+      template: "./public/index.html",
+    }),
+  ],
+};

--- a/shared-context/package.json
+++ b/shared-context/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "lerna run --scope @shared-context/* --parallel start",
+    "build": "lerna run --scope @shared-context/* build",
+    "serve": "lerna run --scope @shared-context/* --parallel serve"
+  }
+}

--- a/shared-context/shared-library/package.json
+++ b/shared-context/shared-library/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@shared-context/shared-library",
+  "version": "0.0.0",
+  "private": true,
+  "main": "./src/index.js",
+  "peerDependencies": {
+    "react": "^16.13.0"
+  }
+}

--- a/shared-context/shared-library/src/NameContextProvider.js
+++ b/shared-context/shared-library/src/NameContextProvider.js
@@ -1,0 +1,3 @@
+import React from "react";
+
+export const NameContextProvider = React.createContext("No name provided");

--- a/shared-context/shared-library/src/index.js
+++ b/shared-context/shared-library/src/index.js
@@ -1,0 +1,1 @@
+export * from "./NameContextProvider";


### PR DESCRIPTION
Add example where two apps share the same federated context provider.

Copied from: https://github.com/mizx/module-federation-examples/tree/master/context-provider