### PR TITLE
Update shared-routing example webpack.config fixing invalid reference

### DIFF
--- a/shared-routing/dashboard/webpack.config.js
+++ b/shared-routing/dashboard/webpack.config.js
@@ -2,7 +2,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack").container
   .ModuleFederationPlugin;
 const path = require("path");
-const deps = require("./package.json").dependen;
+const deps = require("./package.json").dependencies;
 module.exports = {
   entry: "./src/index",
   mode: "development",


### PR DESCRIPTION
Was unable to run this example until I fixed this