### PR TITLE
getting dependencies correctly

### DIFF
--- a/shared-routing/dashboard/webpack.config.js
+++ b/shared-routing/dashboard/webpack.config.js
@@ -2,7 +2,7 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack").container
   .ModuleFederationPlugin;
 const path = require("path");
-const deps = require("./package.json").dependen;
+const deps = require("./package.json").dependencies;
 module.exports = {
   entry: "./src/index",
   mode: "development",


### PR DESCRIPTION
Getting dependencies correctly in webpack.config for dashboard app in shared-routing example.

I was not able to get the example to work properly without this change.

> Keep up the good work - really love what you are doing with module federation