### PR TITLE
Fix lodash version in example

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,11 @@
     "helpers:disableTypesNodeMajor",
     ":pinAllExceptPeerDependencies",
     ":pinOnlyDevDependencies"
+  ],
+  "packageRules": [
+    {
+      "paths": ["version-discrepancy/app1/package.json"],
+      "ignoreDeps": ["lodash"]
+    }
   ]
 }

--- a/version-discrepancy/app1/package.json
+++ b/version-discrepancy/app1/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "lodash": "4.17.15",
+    "lodash": "4.10.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11280,6 +11280,11 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
+lodash@4.10.0:
+  version "4.10.0"
+  resolved "https://artifactory.homeawaycorp.com/artifactory/api/npm/npm/lodash/-/lodash-4.10.0.tgz#3d8f3ac7a5a904fdb01e2cfe1401879bf9652c6a"
+  integrity sha1-PY86x6WpBP2wHiz+FAGHm/llLGo=
+
 lodash@4.17.15, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.5, lodash@^4.2.1, lodash@~4.17.10, lodash@~4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"


### PR DESCRIPTION
I noticed that the `version-discrepancy` example was actually using the same version of lodash for both `app1` and `app2` due to an [automated renovate PR](https://github.com/module-federation/module-federation-examples/pull/14). I've fixed the `app1` dependency to `4.10.0` as intended and added a renovate configuration to prevent it from updating in the future.