### PR TITLE
Add dependency bundle-loader v0.5.6 to typescript example

### DIFF
--- a/typescript/app1/package.json
+++ b/typescript/app1/package.json
@@ -9,6 +9,7 @@
     "@types/react": "16.9.43",
     "@types/react-dom": "16.9.8",
     "babel-loader": "8.1.0",
+    "bundle-loader": "0.5.6",
     "html-webpack-plugin": "git://github.com/ScriptedAlchemy/html-webpack-plugin#master",
     "serve": "11.3.2",
     "typescript": "3.9.6",

--- a/typescript/app2/package.json
+++ b/typescript/app2/package.json
@@ -9,6 +9,7 @@
     "@types/react": "16.9.43",
     "@types/react-dom": "16.9.8",
     "babel-loader": "8.1.0",
+    "bundle-loader": "0.5.6",
     "html-webpack-plugin": "git://github.com/ScriptedAlchemy/html-webpack-plugin#master",
     "serve": "11.3.2",
     "typescript": "3.9.6",


### PR DESCRIPTION
Add bundle-loader dependency to fix this error during build:
```
ERROR in ./src/index.tsx 2:0-36
Module not found: Error: Can't resolve 'bundle-loader' in '/Users/quentinluc/Documents/Work/R&D/quentinluc/module-federation-examples/typescript/app1'

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```