### PR TITLE
Update client-cities.module.ts

### DIFF
--- a/angular-universal-ssr/client-app/src/app/client-cities/client-cities.module.ts
+++ b/angular-universal-ssr/client-app/src/app/client-cities/client-cities.module.ts
@@ -2,10 +2,12 @@ import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { ClientCitiesHomeComponent } from "./client-cities-home/client-cities-home.component";
 import { ClientCitiesRoutingModule } from "./client-cities-routing.module";
+import { ClientCityComponent } from "./client-city/client-city.component"
 
 @NgModule({
-  declarations: [ClientCitiesHomeComponent],
+  declarations: [ClientCitiesHomeComponent, ClientCityComponent],
   imports: [CommonModule, ClientCitiesRoutingModule],
   exports: [ClientCitiesHomeComponent],
+  entryComponents: [ClientCityComponent]
 })
 export class ClientCitiesModule {}


### PR DESCRIPTION
There's an issue when running the client-app alone. Click on any of the cities, 
Prague or Saint-Petersburg and you get an error on the console:
ERROR Error: Uncaught (in promise): Error: No component factory found for i. 
To fix that, 'ClientCityComponent' needs to be added to entryComponents