### PR TITLE
Remove unnecessary npx from test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "submodules": "git pull --recurse-submodules",
     "prettier": "prettier --write \"**/*.{js,json,md,ts,tsx}\"",
     "prettier:check": "prettier --list-different \"**/*.{js,json,md,ts,tsx}\"",
-    "test": "npx jest test/index.spec.js --maxWorkers=2"
+    "test": "jest test/index.spec.js --maxWorkers=2"
   }
 }


### PR DESCRIPTION
We already have jest in devDependencies so npx isn't required.