### PR TITLE
refactor: version-discrepancy

### DIFF
--- a/version-discrepancy/app1/webpack.config.js
+++ b/version-discrepancy/app1/webpack.config.js
@@ -1,6 +1,7 @@
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack").container
   .ModuleFederationPlugin;
+const deps = require("./package.json").dependencies;
 const path = require("path");
 
 module.exports = {
@@ -34,7 +35,9 @@ module.exports = {
       shared: {
         react: "react",
         "react-dom": "react-dom",
-        [`lodash-${require("lodash").VERSION}`]: "lodash",
+        lodash: {
+          requiredVersion: deps["lodash"],
+        },
       },
     }),
     new HtmlWebpackPlugin({

--- a/version-discrepancy/app2/webpack.config.js
+++ b/version-discrepancy/app2/webpack.config.js
@@ -1,6 +1,7 @@
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const ModuleFederationPlugin = require("webpack").container
   .ModuleFederationPlugin;
+const deps = require("./package.json").dependencies;
 const path = require("path");
 
 module.exports = {
@@ -36,7 +37,9 @@ module.exports = {
       shared: {
         react: "react",
         "react-dom": "react-dom",
-        [`lodash-${require("lodash").VERSION}`]: "lodash",
+        lodash: {
+          requiredVersion: deps["lodash"],
+        },
       },
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Using requiredVersion option instead of manually naming shared module. 

A query here. If I specify `singleton: true`. Is there a way to explicitly specify which version to pick?