### PR TITLE
fix: consumes:133 Uncaught Error: Shared module is not available for …

### DIFF
--- a/angular11-microfrontends/projects/mdmf-profile/webpack.config.js
+++ b/angular11-microfrontends/projects/mdmf-profile/webpack.config.js
@@ -19,9 +19,9 @@ module.exports = {
           "./projects/mdmf-profile/src/app/profile/profile.module.ts",
       },
       shared: {
-        "@angular/core": { singleton: true },
-        "@angular/common": { singleton: true },
-        "@angular/router": { singleton: true },
+        "@angular/core": { eager: true, singleton: true },
+        "@angular/common": { eager: true, singleton: true },
+        "@angular/router": { eager: true, singleton: true },
       },
     }),
   ],


### PR DESCRIPTION
Fix angular11-microfrontends/projects/mdmf-profile is not working
[angular11-microfrontends/projects/mdmf-profile is not working](https://github.com/module-federation/module-federation-examples/issues/505)