### PR TITLE
added concurrently dependency in order to run start after install

### DIFF
--- a/comprehensive-demo/package.json
+++ b/comprehensive-demo/package.json
@@ -7,6 +7,7 @@
     "clean": "lerna run --scope @comprehensive-demo/* --parallel clean"
   },
   "devDependencies": {
+    "concurrently": "^5.3.0",
     "lerna": "3.22.1"
   }
 }


### PR DESCRIPTION
the dependency concurrently is missing from the package.json. Its part of the start command script.