### PR TITLE
update webpack-cli to 4.2

### DIFF
--- a/advanced-api/automatic-vendor-sharing/app1/package.json
+++ b/advanced-api/automatic-vendor-sharing/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/advanced-api/automatic-vendor-sharing/app2/package.json
+++ b/advanced-api/automatic-vendor-sharing/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/advanced-api/dynamic-remotes/app1/package.json
+++ b/advanced-api/dynamic-remotes/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/advanced-api/dynamic-remotes/app2/package.json
+++ b/advanced-api/dynamic-remotes/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {
@@ -19,8 +19,8 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "moment": "^2.24.0",
     "react": "^16.13.0",
-    "react-dom": "^16.13.0",
-    "moment": "^2.24.0"
+    "react-dom": "^16.13.0"
   }
 }

--- a/advanced-api/dynamic-remotes/app3/package.json
+++ b/advanced-api/dynamic-remotes/app3/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/angular-universal-ssr/client-app/package.json
+++ b/angular-universal-ssr/client-app/package.json
@@ -28,10 +28,10 @@
     "zone.js": "~0.11.0"
   },
   "devDependencies": {
-    "@ngtools/webpack": "file:../patched_packages/_ngtools_webpack.tgz",
     "@angular-devkit/build-angular": "0.1000.3",
     "@angular/cli": "10.0.3",
     "@angular/compiler-cli": "10.1.5",
+    "@ngtools/webpack": "file:../patched_packages/_ngtools_webpack.tgz",
     "@types/node": "12.19.1",
     "clean-webpack-plugin": "3.0.0",
     "html-webpack-plugin": "4.5.0",
@@ -41,6 +41,6 @@
     "tslint": "6.1.3",
     "typescript": "4.0.3",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.2.0"
   }
 }

--- a/angular-universal-ssr/host-app/package.json
+++ b/angular-universal-ssr/host-app/package.json
@@ -47,6 +47,6 @@
     "tslint": "6.1.3",
     "typescript": "4.0.3",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.2.0"
   }
 }

--- a/basic-host-remote/app1/package.json
+++ b/basic-host-remote/app1/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/basic-host-remote/app2/package.json
+++ b/basic-host-remote/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/bi-directional/app1/package.json
+++ b/bi-directional/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/bi-directional/app2/package.json
+++ b/bi-directional/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/comprehensive-demo/app-04/package.json
+++ b/comprehensive-demo/app-04/package.json
@@ -5,15 +5,15 @@
   "devDependencies": {
     "cross-env": "7.0.2",
     "css-loader": "5.0.1",
+    "html-webpack-plugin": "4.5.0",
     "mini-css-extract-plugin": "1.2.1",
+    "serve": "11.3.2",
     "style-loader": "2.0.0",
     "svelte": "3.29.4",
     "svelte-loader": "2.13.6",
-    "html-webpack-plugin": "4.5.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
-    "webpack-dev-server": "3.11.0",
-    "serve": "11.3.2"
+    "webpack-cli": "4.2.0",
+    "webpack-dev-server": "3.11.0"
   },
   "scripts": {
     "build": "cross-env NODE_ENV=production webpack",

--- a/comprehensive-demo/app-05/package.json
+++ b/comprehensive-demo/app-05/package.json
@@ -12,13 +12,13 @@
   },
   "devDependencies": {
     "cross-env": "7.0.2",
+    "html-webpack-plugin": "4.5.0",
     "lit-element": "2.4.0",
+    "serve": "11.3.2",
     "ts-loader": "5.4.5",
     "typescript": "4.0.3",
-    "html-webpack-plugin": "4.5.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
-    "webpack-dev-server": "3.11.0",
-    "serve": "11.3.2"
+    "webpack-cli": "4.2.0",
+    "webpack-dev-server": "3.11.0"
   }
 }

--- a/dashboard-example/app1/package.json
+++ b/dashboard-example/app1/package.json
@@ -5,13 +5,13 @@
   "devDependencies": {
     "@babel/core": "7.12.3",
     "@babel/preset-react": "7.12.1",
+    "@module-federation/dashboard-plugin": "1.1.0",
     "babel-loader": "8.1.0",
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
-    "webpack-dev-server": "3.11.0",
-    "@module-federation/dashboard-plugin": "1.1.0"
+    "webpack-cli": "4.2.0",
+    "webpack-dev-server": "3.11.0"
   },
   "scripts": {
     "start": "node --inspect ../../node_modules/webpack-dev-server/bin/webpack-dev-server.js",

--- a/dashboard-example/app2/package.json
+++ b/dashboard-example/app2/package.json
@@ -5,13 +5,13 @@
   "devDependencies": {
     "@babel/core": "7.12.3",
     "@babel/preset-react": "7.12.1",
+    "@module-federation/dashboard-plugin": "1.1.0",
     "babel-loader": "8.1.0",
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
-    "webpack-dev-server": "3.11.0",
-    "@module-federation/dashboard-plugin": "1.1.0"
+    "webpack-cli": "4.2.0",
+    "webpack-dev-server": "3.11.0"
   },
   "scripts": {
     "start": "webpack-cli serve",

--- a/different-react-versions/app1/package.json
+++ b/different-react-versions/app1/package.json
@@ -11,7 +11,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/different-react-versions/app2/package.json
+++ b/different-react-versions/app2/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/dynamic-system-host/app1/package.json
+++ b/dynamic-system-host/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/dynamic-system-host/app2/package.json
+++ b/dynamic-system-host/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/dynamic-system-host/app3/package.json
+++ b/dynamic-system-host/app3/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/nested/app1/package.json
+++ b/nested/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/nested/app2/package.json
+++ b/nested/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/nested/app3/package.json
+++ b/nested/app3/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/nextjs-sidecar/dog-admin/package.json
+++ b/nextjs-sidecar/dog-admin/package.json
@@ -21,7 +21,7 @@
     "html-webpack-plugin": "4.5.0",
     "style-loader": "2.0.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "dependencies": {

--- a/redux-reducer-injection/app1/package.json
+++ b/redux-reducer-injection/app1/package.json
@@ -11,13 +11,13 @@
     "redux": "^4.0.5"
   },
   "devDependencies": {
+    "@babel/core": "7.12.3",
+    "@babel/preset-react": "7.12.1",
     "babel-loader": "8.1.0",
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
-    "@babel/core": "7.12.3",
-    "@babel/preset-react": "7.12.1"
+    "webpack-cli": "4.2.0"
   },
   "scripts": {
     "start": "webpack --watch",

--- a/redux-reducer-injection/app2/package.json
+++ b/redux-reducer-injection/app2/package.json
@@ -15,7 +15,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.2.0"
   },
   "scripts": {
     "start": "webpack --watch",

--- a/self-healing/app1/package.json
+++ b/self-healing/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/self-healing/app2/package.json
+++ b/self-healing/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/server-side-rendering/website1/package.json
+++ b/server-side-rendering/website1/package.json
@@ -86,7 +86,7 @@
     "style-loader": "2.0.0",
     "url-loader": "4.1.1",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-middleware": "4.0.2",
     "webpack-hot-middleware": "2.25.0",
     "webpack-hot-server-middleware": "0.6.1",

--- a/server-side-rendering/website2/package.json
+++ b/server-side-rendering/website2/package.json
@@ -88,7 +88,7 @@
     "style-loader": "2.0.0",
     "url-loader": "4.1.1",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-middleware": "4.0.2",
     "webpack-hot-middleware": "2.25.0",
     "webpack-hot-server-middleware": "0.6.1",

--- a/shared-context/app1/package.json
+++ b/shared-context/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-context/app2/package.json
+++ b/shared-context/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routes2/app1/package.json
+++ b/shared-routes2/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routes2/app2/package.json
+++ b/shared-routes2/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/dashboard/package.json
+++ b/shared-routing/dashboard/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/order/package.json
+++ b/shared-routing/order/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/profile/package.json
+++ b/shared-routing/profile/package.json
@@ -11,7 +11,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/sales/package.json
+++ b/shared-routing/sales/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/shell/package.json
+++ b/shared-routing/shell/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/startup-code/app1/package.json
+++ b/startup-code/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/startup-code/app2/package.json
+++ b/startup-code/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/typescript/app1/package.json
+++ b/typescript/app1/package.json
@@ -14,7 +14,7 @@
     "serve": "11.3.2",
     "typescript": "4.0.3",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/typescript/app2/package.json
+++ b/typescript/app2/package.json
@@ -14,7 +14,7 @@
     "serve": "11.3.2",
     "typescript": "4.0.3",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/version-discrepancy/app1/package.json
+++ b/version-discrepancy/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/version-discrepancy/app2/package.json
+++ b/version-discrepancy/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.2.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/vue3-demo/home/package.json
+++ b/vue3-demo/home/package.json
@@ -23,7 +23,7 @@
     "url-loader": "4.1.1",
     "vue-loader": "16.0.0-beta.8",
     "webpack": "5.6.0",
-    "webpack-dev-server": "3.11.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.2.0",
+    "webpack-dev-server": "3.11.0"
   }
 }

--- a/vue3-demo/layout/package.json
+++ b/vue3-demo/layout/package.json
@@ -23,7 +23,7 @@
     "url-loader": "4.1.1",
     "vue-loader": "16.0.0-beta.8",
     "webpack": "5.6.0",
-    "webpack-dev-server": "3.11.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.2.0",
+    "webpack-dev-server": "3.11.0"
   }
 }


### PR DESCRIPTION
via `yarn upgrade-interactive --latest`.

With webpack-cli at 4.1, certain examples fail to run with the following
error message:

```
[webpack-cli] The command moved into a separate package: @webpack-cli/serve
```