### PR TITLE
#551 Hotfix/update version for `webpack-cli` package to 4.3.0

### DIFF
--- a/advanced-api/automatic-vendor-sharing/app1/package.json
+++ b/advanced-api/automatic-vendor-sharing/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/advanced-api/automatic-vendor-sharing/app2/package.json
+++ b/advanced-api/automatic-vendor-sharing/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/advanced-api/dynamic-remotes/app1/package.json
+++ b/advanced-api/dynamic-remotes/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/advanced-api/dynamic-remotes/app2/package.json
+++ b/advanced-api/dynamic-remotes/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/advanced-api/dynamic-remotes/app3/package.json
+++ b/advanced-api/dynamic-remotes/app3/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/angular-universal-ssr/client-app/package.json
+++ b/angular-universal-ssr/client-app/package.json
@@ -41,6 +41,6 @@
     "tslint": "6.1.3",
     "typescript": "4.0.3",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   }
 }

--- a/angular-universal-ssr/host-app/package.json
+++ b/angular-universal-ssr/host-app/package.json
@@ -47,6 +47,6 @@
     "tslint": "6.1.3",
     "typescript": "4.0.3",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   }
 }

--- a/basic-host-remote/app1/package.json
+++ b/basic-host-remote/app1/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/basic-host-remote/app2/package.json
+++ b/basic-host-remote/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/bi-directional/app1/package.json
+++ b/bi-directional/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/bi-directional/app2/package.json
+++ b/bi-directional/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/comprehensive-demo/app-04/package.json
+++ b/comprehensive-demo/app-04/package.json
@@ -11,7 +11,7 @@
     "svelte-loader": "2.13.6",
     "html-webpack-plugin": "4.5.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0",
     "serve": "11.3.2"
   },

--- a/comprehensive-demo/app-05/package.json
+++ b/comprehensive-demo/app-05/package.json
@@ -17,7 +17,7 @@
     "typescript": "4.0.3",
     "html-webpack-plugin": "4.5.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0",
     "serve": "11.3.2"
   }

--- a/dashboard-example/app1/package.json
+++ b/dashboard-example/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0",
     "@module-federation/dashboard-plugin": "1.1.0"
   },

--- a/dashboard-example/app2/package.json
+++ b/dashboard-example/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0",
     "@module-federation/dashboard-plugin": "1.1.0"
   },

--- a/different-react-versions/app1/package.json
+++ b/different-react-versions/app1/package.json
@@ -11,7 +11,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/different-react-versions/app2/package.json
+++ b/different-react-versions/app2/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/dynamic-system-host/app1/package.json
+++ b/dynamic-system-host/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/dynamic-system-host/app2/package.json
+++ b/dynamic-system-host/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/dynamic-system-host/app3/package.json
+++ b/dynamic-system-host/app3/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/multi-threaded-ssr/website1/package.json
+++ b/multi-threaded-ssr/website1/package.json
@@ -84,7 +84,7 @@
     "style-loader": "2.0.0",
     "url-loader": "4.1.1",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-middleware": "4.0.2",
     "webpack-hot-middleware": "2.25.0",
     "webpack-hot-server-middleware": "0.6.1",

--- a/multi-threaded-ssr/website2/package.json
+++ b/multi-threaded-ssr/website2/package.json
@@ -88,7 +88,7 @@
     "style-loader": "2.0.0",
     "url-loader": "4.1.1",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-middleware": "4.0.2",
     "webpack-hot-middleware": "2.25.0",
     "webpack-hot-server-middleware": "0.6.1",

--- a/nested/app1/package.json
+++ b/nested/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/nested/app2/package.json
+++ b/nested/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/nested/app3/package.json
+++ b/nested/app3/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/nextjs-bi-directional/app1/sidecar/package.json
+++ b/nextjs-bi-directional/app1/sidecar/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-react": "7.12.1",
     "babel-loader": "8.1.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   },
   "dependencies": {
     "react": "16.14.0"

--- a/nextjs-bi-directional/app2/sidecar/package.json
+++ b/nextjs-bi-directional/app2/sidecar/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-react": "7.12.1",
     "babel-loader": "8.1.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   },
   "dependencies": {
     "react": "16.14.0"

--- a/nextjs-sidecar/dog-admin/package.json
+++ b/nextjs-sidecar/dog-admin/package.json
@@ -21,7 +21,7 @@
     "html-webpack-plugin": "4.5.0",
     "style-loader": "2.0.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "dependencies": {

--- a/nextjs-sidecar/host/sidecar/package.json
+++ b/nextjs-sidecar/host/sidecar/package.json
@@ -16,7 +16,7 @@
     "@babel/preset-react": "7.12.1",
     "babel-loader": "8.1.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   },
   "dependencies": {
     "react": "16.14.0"

--- a/redux-reducer-injection/app1/package.json
+++ b/redux-reducer-injection/app1/package.json
@@ -15,7 +15,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "@babel/core": "7.12.3",
     "@babel/preset-react": "7.12.1"
   },

--- a/redux-reducer-injection/app2/package.json
+++ b/redux-reducer-injection/app2/package.json
@@ -15,7 +15,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   },
   "scripts": {
     "start": "webpack --watch",

--- a/rollup-federation-demo/rollup-spa/rs-sidecar/package.json
+++ b/rollup-federation-demo/rollup-spa/rs-sidecar/package.json
@@ -21,7 +21,7 @@
     "html-webpack-plugin": "4.5.0",
     "style-loader": "2.0.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "dependencies": {

--- a/rollup-federation-demo/webpack-spa/package.json
+++ b/rollup-federation-demo/webpack-spa/package.json
@@ -18,7 +18,7 @@
     "babel-loader": "8.1.0",
     "npm-run-all": "4.1.5",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   }
 }

--- a/self-healing/app1/package.json
+++ b/self-healing/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/self-healing/app2/package.json
+++ b/self-healing/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/server-side-render-only/package.json
+++ b/server-side-render-only/package.json
@@ -22,7 +22,7 @@
     "nodemon": "2.0.6",
     "lerna": "3.22.1",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   },
   "dependencies": {
     "express": "^4.17.1",

--- a/server-side-rendering/website1/package.json
+++ b/server-side-rendering/website1/package.json
@@ -86,7 +86,7 @@
     "style-loader": "2.0.0",
     "url-loader": "4.1.1",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-middleware": "4.0.2",
     "webpack-hot-middleware": "2.25.0",
     "webpack-hot-server-middleware": "0.6.1",

--- a/server-side-rendering/website2/package.json
+++ b/server-side-rendering/website2/package.json
@@ -88,7 +88,7 @@
     "style-loader": "2.0.0",
     "url-loader": "4.1.1",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-middleware": "4.0.2",
     "webpack-hot-middleware": "2.25.0",
     "webpack-hot-server-middleware": "0.6.1",

--- a/shared-context/app1/package.json
+++ b/shared-context/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-context/app2/package.json
+++ b/shared-context/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routes2/app1/package.json
+++ b/shared-routes2/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routes2/app2/package.json
+++ b/shared-routes2/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/dashboard/package.json
+++ b/shared-routing/dashboard/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/order/package.json
+++ b/shared-routing/order/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/profile/package.json
+++ b/shared-routing/profile/package.json
@@ -11,7 +11,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/sales/package.json
+++ b/shared-routing/sales/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/shared-routing/shell/package.json
+++ b/shared-routing/shell/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/startup-code/app1/package.json
+++ b/startup-code/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/startup-code/app2/package.json
+++ b/startup-code/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/streamed-federation/app1/package.json
+++ b/streamed-federation/app1/package.json
@@ -44,6 +44,6 @@
     "serverless": "1.83.0",
     "serverless-dotenv-plugin": "3.0.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   }
 }

--- a/streamed-federation/federated-middleware/package.json
+++ b/streamed-federation/federated-middleware/package.json
@@ -22,6 +22,6 @@
     "copy-webpack-plugin": "6.2.1",
     "serverless": "1.83.0",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   }
 }

--- a/typescript/app1/package.json
+++ b/typescript/app1/package.json
@@ -14,7 +14,7 @@
     "serve": "11.3.2",
     "typescript": "4.0.3",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/typescript/app2/package.json
+++ b/typescript/app2/package.json
@@ -14,7 +14,7 @@
     "serve": "11.3.2",
     "typescript": "4.0.3",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/version-discrepancy/app1/package.json
+++ b/version-discrepancy/app1/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/version-discrepancy/app2/package.json
+++ b/version-discrepancy/app2/package.json
@@ -9,7 +9,7 @@
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",
-    "webpack-cli": "4.1.0",
+    "webpack-cli": "4.3.0",
     "webpack-dev-server": "3.11.0"
   },
   "scripts": {

--- a/vue3-demo/home/package.json
+++ b/vue3-demo/home/package.json
@@ -24,6 +24,6 @@
     "vue-loader": "16.0.0-beta.8",
     "webpack": "5.6.0",
     "webpack-dev-server": "3.11.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   }
 }

--- a/vue3-demo/layout/package.json
+++ b/vue3-demo/layout/package.json
@@ -24,6 +24,6 @@
     "vue-loader": "16.0.0-beta.8",
     "webpack": "5.6.0",
     "webpack-dev-server": "3.11.0",
-    "webpack-cli": "4.1.0"
+    "webpack-cli": "4.3.0"
   }
 }


### PR DESCRIPTION
**PR for updating version `webpack-cli` package to 4.3.0**

Closes #551

**Short description for issue:**
* tried to start `bi-directional` example
* get the error ` [webpack-cli] Promise rejection: TypeError: Class constructor ServeCommand cannot be invoked without 'new`

**Link to the issue from `webpack-cli`:**
Error when run npm start: Class constructor ServeCommand cannot be invoked without 'new' [#2272](https://github.com/webpack/webpack-cli/issues/2272)

**How to fix:**
> You should update webpack-cli to the 4.3.0

[Link to the comment](https://github.com/webpack/webpack-cli/issues/2272#issuecomment-752048270) from @alexander-akait

Thanks in advance! 🙏