### PR TITLE
#542 Hotfix/add `lerna` to devDeps for `different-react-versions` example

### DIFF
--- a/different-react-versions/package.json
+++ b/different-react-versions/package.json
@@ -5,5 +5,8 @@
     "build": "lerna run --scope @different-react-versions/* build",
     "serve": "lerna run --scope @different-react-versions/* --parallel serve",
     "clean": "lerna run --scope @different-react-versions/* --parallel clean"
+  },
+  "devDependencies": {
+    "lerna": "3.22.1"
   }
 }


### PR DESCRIPTION
**PR for adding `lerna` package to devDependencies for `different-react-versions` example**

Closes #542

**Short description for issue:**
* tried to start `different-react-versions` example
* get the error: `/bin/sh: lerna: command not found`

**How to fix:**
Add `lerna` package to devDependencies as for other examples.

Thanks in advance! 🙏