### PR TITLE
Remove dependency on deprecated bundle-loader

### DIFF
--- a/basic-host-remote/app1/package.json
+++ b/basic-host-remote/app1/package.json
@@ -6,7 +6,6 @@
     "@babel/core": "7.12.3",
     "@babel/preset-react": "7.12.1",
     "babel-loader": "8.1.0",
-    "bundle-loader": "0.5.6",
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",

--- a/basic-host-remote/app1/src/index.js
+++ b/basic-host-remote/app1/src/index.js
@@ -1,2 +1,1 @@
-import bootstrap from "./bootstrap";
-bootstrap();
+import('./bootstrap');

--- a/basic-host-remote/app1/webpack.config.js
+++ b/basic-host-remote/app1/webpack.config.js
@@ -15,13 +15,6 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /bootstrap\.js$/,
-        loader: "bundle-loader",
-        options: {
-          lazy: true,
-        },
-      },
-      {
         test: /\.jsx?$/,
         loader: "babel-loader",
         exclude: /node_modules/,

--- a/different-react-versions/app1/package.json
+++ b/different-react-versions/app1/package.json
@@ -7,7 +7,6 @@
     "@babel/plugin-proposal-class-properties": "7.12.1",
     "@babel/preset-react": "7.12.1",
     "babel-loader": "8.1.0",
-    "bundle-loader": "0.5.6",
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "webpack": "5.6.0",

--- a/typescript/app1/package.json
+++ b/typescript/app1/package.json
@@ -9,7 +9,6 @@
     "@types/react": "16.14.1",
     "@types/react-dom": "16.9.8",
     "babel-loader": "8.1.0",
-    "bundle-loader": "0.5.6",
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "typescript": "4.0.3",

--- a/typescript/app1/src/index.tsx
+++ b/typescript/app1/src/index.tsx
@@ -1,3 +1,1 @@
-// @ts-ignore
-import bootstrap from "./bootstrap";
-bootstrap(() => {});
+import('./bootstrap');

--- a/typescript/app1/webpack.config.js
+++ b/typescript/app1/webpack.config.js
@@ -19,13 +19,6 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /bootstrap\.tsx$/,
-        loader: "bundle-loader",
-        options: {
-          lazy: true,
-        },
-      },
-      {
         test: /\.tsx?$/,
         loader: "babel-loader",
         exclude: /node_modules/,

--- a/typescript/app2/package.json
+++ b/typescript/app2/package.json
@@ -9,7 +9,6 @@
     "@types/react": "16.14.1",
     "@types/react-dom": "16.9.8",
     "babel-loader": "8.1.0",
-    "bundle-loader": "0.5.6",
     "html-webpack-plugin": "4.5.0",
     "serve": "11.3.2",
     "typescript": "4.0.3",

--- a/typescript/app2/src/index.tsx
+++ b/typescript/app2/src/index.tsx
@@ -1,3 +1,1 @@
-// @ts-ignore
-import bootstrap from "./bootstrap";
-bootstrap(() => {});
+import('./bootstrap');

--- a/typescript/app2/webpack.config.js
+++ b/typescript/app2/webpack.config.js
@@ -19,13 +19,6 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /bootstrap\.tsx$/,
-        loader: "bundle-loader",
-        options: {
-          lazy: true,
-        },
-      },
-      {
         test: /\.tsx?$/,
         loader: "babel-loader",
         exclude: /node_modules/,


### PR DESCRIPTION
Bundle loader is no longer maintained: https://github.com/webpack-contrib/bundle-loader - the recommended method is to use dynamic imports.

It was also causing a console error in the basic remote host which is likely the first example most people will look at.