### PR TITLE
chore(deps): update webpack to 5.11.1

### DIFF
--- a/nextjs/next1/package.json
+++ b/nextjs/next1/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "resolutions": {
-    "webpack": "5.6.0",
+    "webpack": "5.11.1",
     "next": "^10.0.0"
   },
   "dependencies": {
@@ -18,6 +18,6 @@
     "next-compose-plugins": "^2.2.0",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "webpack": "5.6.0"
+    "webpack": "5.11.1"
   }
 }

--- a/nextjs/next2/package.json
+++ b/nextjs/next2/package.json
@@ -8,11 +8,11 @@
     "start": "next start -p 3001"
   },
   "resolutions": {
-    "webpack": "^5.2.0",
+    "webpack": "^5.11.1",
     "next": "^10.0.0"
   },
   "dependencies": {
-    "webpack": "^5.2.0",
+    "webpack": "^5.11.1",
     "@module-federation/nextjs-mf": "0.0.2",
     "next": "^10.0.0",
     "next-compose-plugins": "^2.2.0",


### PR DESCRIPTION
When running this example locally, there was an error that said webpack needed to be updated to `5.11.1` to work.