### PR TITLE
fix(vue3-demo): reducing css-loader's version

### DIFF
--- a/vue3-demo/home/package.json
+++ b/vue3-demo/home/package.json
@@ -16,10 +16,10 @@
   },
   "devDependencies": {
     "@vue/compiler-sfc": "3.0.0",
-    "css-loader": "5.0.1",
+    "css-loader": "3.6.0",
     "file-loader": "6.2.0",
     "html-webpack-plugin": "4.5.1",
-    "mini-css-extract-plugin": "1.3.4",
+    "mini-css-extract-plugin": "0.9.0",
     "url-loader": "4.1.1",
     "vue-loader": "16.0.0-beta.8",
     "webpack": "5.14.0",

--- a/vue3-demo/layout/package.json
+++ b/vue3-demo/layout/package.json
@@ -16,10 +16,10 @@
   },
   "devDependencies": {
     "@vue/compiler-sfc": "3.0.0",
-    "css-loader": "5.0.1",
+    "css-loader": "3.6.0",
     "file-loader": "6.2.0",
     "html-webpack-plugin": "4.5.1",
-    "mini-css-extract-plugin": "1.3.4",
+    "mini-css-extract-plugin": "0.9.0",
     "url-loader": "4.1.1",
     "vue-loader": "16.0.0-beta.8",
     "webpack": "5.14.0",


### PR DESCRIPTION
The current css-loader and mini-css-extract-plugin's version is too high, the vue3-demo cannot run because of this.

After i downgrade the version, the demo works