### PR TITLE
fix(nested): remove app3 remote from app1

### DIFF
--- a/nested/app1/webpack.config.js
+++ b/nested/app1/webpack.config.js
@@ -30,7 +30,6 @@ module.exports = {
       name: "app1",
       remotes: {
         app2: `app2@${getRemoteEntryUrl(3002)}`,
-        app3: `app3@${getRemoteEntryUrl(3003)}`,
       },
       shared: { react: { singleton: true }, "react-dom": { singleton: true } },
     }),


### PR DESCRIPTION
Without link to app3@remote it's more representative - you can infinitely insert microfrontends deep into each other