### PR TITLE
updated webpack shared deps to be an object

### DIFF
--- a/shared-routing/dashboard/webpack.config.js
+++ b/shared-routing/dashboard/webpack.config.js
@@ -56,19 +56,17 @@ module.exports = {
       exposes: {
         "./DashboardService": "./src/DashboardService",
       },
-      shared: [
-        {
-          ...deps,
-          react: {
-            singleton: true,
-            requiredVersion: deps.react,
-          },
-          "react-dom": {
-            singleton: true,
-            requiredVersion: deps["react-dom"],
-          },
+      shared: {
+        ...deps,
+        react: {
+          singleton: true,
+          requiredVersion: deps.react,
         },
-      ],
+        "react-dom": {
+          singleton: true,
+          requiredVersion: deps["react-dom"],
+        },
+      },
     }),
     new HtmlWebpackPlugin({
       template: "./public/index.html",

--- a/shared-routing/order/webpack.config.js
+++ b/shared-routing/order/webpack.config.js
@@ -53,19 +53,17 @@ module.exports = {
         "./RecentOrdersWidget": "./src/RecentOrdersWidget",
         "./OrderService": "./src/OrderService",
       },
-      shared: [
-        {
-          ...deps,
-          react: {
-            singleton: true,
-            requiredVersion: deps.react,
-          },
-          "react-dom": {
-            singleton: true,
-            requiredVersion: deps["react-dom"],
-          },
+      shared: {
+        ...deps,
+        react: {
+          singleton: true,
+          requiredVersion: deps.react,
         },
-      ],
+        "react-dom": {
+          singleton: true,
+          requiredVersion: deps["react-dom"],
+        },
+      },
     }),
     new HtmlWebpackPlugin({
       template: "./public/index.html",

--- a/shared-routing/profile/webpack.config.js
+++ b/shared-routing/profile/webpack.config.js
@@ -57,19 +57,17 @@ module.exports = {
       exposes: {
         "./ProfilePage": "./src/ProfilePage",
       },
-      shared: [
-        {
-          ...deps,
-          react: {
-            singleton: true,
-            requiredVersion: deps.react,
-          },
-          "react-dom": {
-            singleton: true,
-            requiredVersion: deps["react-dom"],
-          },
+      shared: {
+        ...deps,
+        react: {
+          singleton: true,
+          requiredVersion: deps.react,
         },
-      ],
+        "react-dom": {
+          singleton: true,
+          requiredVersion: deps["react-dom"],
+        },
+      },
     }),
     new HtmlWebpackPlugin({
       template: "./public/index.html",

--- a/shared-routing/sales/webpack.config.js
+++ b/shared-routing/sales/webpack.config.js
@@ -51,19 +51,17 @@ module.exports = {
         "./TodayWidget": "./src/TodayWidget",
         "./DepositsWidget": "./src/DepositsWidget",
       },
-      shared: [
-        {
-          ...deps,
-          react: {
-            singleton: true,
-            requiredVersion: deps.react,
-          },
-          "react-dom": {
-            singleton: true,
-            requiredVersion: deps["react-dom"],
-          },
+      shared: {
+        ...deps,
+        react: {
+          singleton: true,
+          requiredVersion: deps.react,
         },
-      ],
+        "react-dom": {
+          singleton: true,
+          requiredVersion: deps["react-dom"],
+        },
+      },
     }),
     new HtmlWebpackPlugin({
       template: "./public/index.html",


### PR DESCRIPTION
I'm not sure if this is needed, but I didn't see this pattern anywhere else. It seems like you either have a shared object or array. But, these files have an array of a single object of which the contents are multiple packages. 

Does it work the same? And if so, maybe this is still better just for consistency with docs and other examples? 