### PR TITLE
fix: webpack-dev-server v4 config issues

### DIFF
--- a/advanced-api/automatic-vendor-sharing/app1/webpack.config.js
+++ b/advanced-api/automatic-vendor-sharing/app1/webpack.config.js
@@ -17,7 +17,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   target: "web",

--- a/advanced-api/automatic-vendor-sharing/app2/webpack.config.js
+++ b/advanced-api/automatic-vendor-sharing/app2/webpack.config.js
@@ -17,7 +17,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   target: "web",

--- a/advanced-api/dynamic-remotes-runtime-environment-variables/host/webpack.config.js
+++ b/advanced-api/dynamic-remotes-runtime-environment-variables/host/webpack.config.js
@@ -8,7 +8,9 @@ module.exports = {
     mode: 'development',
     devtool: 'source-map',
     devServer: {
-        contentBase: path.join(__dirname, 'dist'),
+      static: {
+        directory: path.join(__dirname, "dist"),
+      },
         port: 3000,
     },
     output: {

--- a/advanced-api/dynamic-remotes-runtime-environment-variables/remote/webpack.config.js
+++ b/advanced-api/dynamic-remotes-runtime-environment-variables/remote/webpack.config.js
@@ -9,7 +9,9 @@ module.exports = {
     mode: 'development',
     devtool: 'source-map',
     devServer: {
-        contentBase: path.join(__dirname, 'dist'),
+        static: {
+            directory: path.join(__dirname, "dist"),
+        },
         port: 3001,
         headers: {
             // Enable wide open CORS

--- a/advanced-api/dynamic-remotes-synchronous-imports/app1/webpack.config.js
+++ b/advanced-api/dynamic-remotes-synchronous-imports/app1/webpack.config.js
@@ -10,7 +10,9 @@ module.exports = {
   mode: "development",
   target: "web",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: app1Module.port,
   },
   output: {

--- a/advanced-api/dynamic-remotes-synchronous-imports/app2/webpack.config.js
+++ b/advanced-api/dynamic-remotes-synchronous-imports/app2/webpack.config.js
@@ -9,7 +9,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: app2Module.port,
   },
   target: "web",

--- a/advanced-api/dynamic-remotes/app1/webpack.config.js
+++ b/advanced-api/dynamic-remotes/app1/webpack.config.js
@@ -8,7 +8,9 @@ module.exports = {
   mode: "development",
   target: "web",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/advanced-api/dynamic-remotes/app2/webpack.config.js
+++ b/advanced-api/dynamic-remotes/app2/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   mode: "development",
   target: "web",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/advanced-api/dynamic-remotes/app3/webpack.config.js
+++ b/advanced-api/dynamic-remotes/app3/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3003,
   },
   target: "web",

--- a/angular-universal-ssr/client-app/webpack/client-app.js
+++ b/angular-universal-ssr/client-app/webpack/client-app.js
@@ -44,7 +44,9 @@ module.exports = (env = {}) => {
       }),
     ],
     devServer: {
-      contentBase: buildFolder,
+      static: {
+        directory: buildFolder,
+      },
       port: 5000,
     },
     module: {

--- a/basic-host-remote/app1/webpack.config.js
+++ b/basic-host-remote/app1/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/basic-host-remote/app2/webpack.config.js
+++ b/basic-host-remote/app2/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/bi-directional/app1/webpack.config.js
+++ b/bi-directional/app1/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/bi-directional/app2/webpack.config.js
+++ b/bi-directional/app2/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/dashboard-example/app1/webpack.config.js
+++ b/dashboard-example/app1/webpack.config.js
@@ -8,7 +8,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/dashboard-example/app2/webpack.config.js
+++ b/dashboard-example/app2/webpack.config.js
@@ -11,7 +11,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/different-react-versions/app1/webpack.config.js
+++ b/different-react-versions/app1/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/different-react-versions/app2/webpack.config.js
+++ b/different-react-versions/app2/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/dynamic-system-host/app1/webpack.config.js
+++ b/dynamic-system-host/app1/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/dynamic-system-host/app2/webpack.config.js
+++ b/dynamic-system-host/app2/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/dynamic-system-host/app3/webpack.config.js
+++ b/dynamic-system-host/app3/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3003,
   },
   output: {

--- a/nested/app1/webpack.config.js
+++ b/nested/app1/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/nested/app2/webpack.config.js
+++ b/nested/app2/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/nested/app3/webpack.config.js
+++ b/nested/app3/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3003,
   },
   output: {

--- a/react-in-vue/home/webpack.config.js
+++ b/react-in-vue/home/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/react-in-vue/layout/webpack.config.js
+++ b/react-in-vue/layout/webpack.config.js
@@ -76,7 +76,9 @@ module.exports = (env = {}) => ({
     new VueLoaderPlugin(),
   ],
   devServer: {
-    contentBase: path.join(__dirname),
+    static: {
+      directory: path.join(__dirname),
+    },
     compress: true,
     port: 3001,
     hot: true,

--- a/rollup-federation-demo/webpack-spa/webpack.config.js
+++ b/rollup-federation-demo/webpack-spa/webpack.config.js
@@ -57,7 +57,9 @@ module.exports = {
     }),
   ],
   devServer: {
-    contentBase: path.join(__dirname),
+    static: {
+      directory: path.join(__dirname),
+    },
     port: 8081,
     headers: {
       "Access-Control-Allow-Origin": "*",

--- a/rust-wasm/packages/host/webpack.config.js
+++ b/rust-wasm/packages/host/webpack.config.js
@@ -27,7 +27,9 @@ module.exports = {
     ],
   },
   devServer: {
-    contentBase: path.resolve(__dirname, "./dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 8080,
     open: true,
   },

--- a/rust-wasm/packages/remote/webpack.config.js
+++ b/rust-wasm/packages/remote/webpack.config.js
@@ -17,7 +17,9 @@ module.exports = {
   },
   devServer: {
     port: 8081,
-    contentBase: path.resolve(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     headers: {
       "Access-Control-Allow-Origin": "http://localhost:8080",
     },

--- a/self-healing/app1/webpack.config.js
+++ b/self-healing/app1/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/self-healing/app2/webpack.config.js
+++ b/self-healing/app2/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/shared-context/app1/webpack.config.js
+++ b/shared-context/app1/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/shared-context/app2/webpack.config.js
+++ b/shared-context/app2/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/shared-routes2/app1/webpack.config.js
+++ b/shared-routes2/app1/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/shared-routes2/app2/webpack.config.js
+++ b/shared-routes2/app2/webpack.config.js
@@ -8,7 +8,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/shared-routing/dashboard/webpack.config.js
+++ b/shared-routing/dashboard/webpack.config.js
@@ -7,11 +7,12 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
     historyApiFallback: true,
-    hot: false,
-    hotOnly: false,
+    hot: "only",
   },
   output: {
     publicPath: "auto",

--- a/shared-routing/order/webpack.config.js
+++ b/shared-routing/order/webpack.config.js
@@ -7,11 +7,12 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
     historyApiFallback: true,
-    hot: false,
-    hotOnly: false,
+    hot: 'only',
   },
   output: {
     publicPath: "auto",

--- a/shared-routing/profile/webpack.config.js
+++ b/shared-routing/profile/webpack.config.js
@@ -7,11 +7,12 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3004,
     historyApiFallback: true,
-    hot: false,
-    hotOnly: false,
+    hot: 'only',
   },
   output: {
     publicPath: "auto",

--- a/shared-routing/sales/webpack.config.js
+++ b/shared-routing/sales/webpack.config.js
@@ -7,11 +7,12 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3003,
     historyApiFallback: true,
-    hot: false,
-    hotOnly: false,
+    hot: "only",
   },
   output: {
     publicPath: "auto",

--- a/shared-routing/shell/webpack.config.js
+++ b/shared-routing/shell/webpack.config.js
@@ -7,11 +7,12 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3000,
     historyApiFallback: true,
-    hot: false,
-    hotOnly: false,
+    hot: "only",
     headers: {
       "Access-Control-Allow-Origin": "*",
       "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",

--- a/startup-code/app1/webpack.config.js
+++ b/startup-code/app1/webpack.config.js
@@ -11,7 +11,9 @@ module.exports = {
   },
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/startup-code/app2/webpack.config.js
+++ b/startup-code/app2/webpack.config.js
@@ -8,7 +8,9 @@ module.exports = {
   },
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/third-party-scripts/app1/webpack.config.js
+++ b/third-party-scripts/app1/webpack.config.js
@@ -6,7 +6,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/typescript/app1/webpack.config.js
+++ b/typescript/app1/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/typescript/app2/webpack.config.js
+++ b/typescript/app2/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/version-discrepancy/app1/webpack.config.js
+++ b/version-discrepancy/app1/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3001,
   },
   output: {

--- a/version-discrepancy/app2/webpack.config.js
+++ b/version-discrepancy/app2/webpack.config.js
@@ -7,7 +7,9 @@ module.exports = {
   entry: "./src/index",
   mode: "development",
   devServer: {
-    contentBase: path.join(__dirname, "dist"),
+    static: {
+      directory: path.join(__dirname, "dist"),
+    },
     port: 3002,
   },
   output: {

--- a/vite-react-simple/rs-sidecart/webpack.config.js
+++ b/vite-react-simple/rs-sidecart/webpack.config.js
@@ -18,7 +18,9 @@ module.exports = {
   },
 
   devServer: {
-    contentBase: path.join(__dirname),
+    static: {
+      directory: path.join(__dirname),
+    },
     port: 8080,
     headers: {
       "Access-Control-Allow-Origin": "*",

--- a/vite-react-simple/webpack-spa/webpack.config.js
+++ b/vite-react-simple/webpack-spa/webpack.config.js
@@ -56,7 +56,9 @@ module.exports = {
     }),
   ],
   devServer: {
-    contentBase: path.join(__dirname),
+    static: {
+      directory: path.join(__dirname),
+    },
     port: 8081,
     headers: {
       "Access-Control-Allow-Origin": "*",

--- a/vue3-demo/home/webpack.config.js
+++ b/vue3-demo/home/webpack.config.js
@@ -75,7 +75,9 @@ module.exports = (env = {}) => ({
     new VueLoaderPlugin(),
   ],
   devServer: {
-    contentBase: path.join(__dirname),
+    static: {
+      directory: path.join(__dirname,
+    },
     compress: true,
     port: 3002,
     hot: true,

--- a/vue3-demo/layout/webpack.config.js
+++ b/vue3-demo/layout/webpack.config.js
@@ -69,7 +69,9 @@ module.exports = (env = {}) => ({
     new VueLoaderPlugin(),
   ],
   devServer: {
-    contentBase: path.join(__dirname),
+    static: {
+      directory: path.join(__dirname),
+    },
     compress: true,
     port: 3001,
     hot: true,


### PR DESCRIPTION
Since webpack-dev-server has upgraded to v4，using `contentBase` in webpack.config.js will cause the following error： 

```
Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.
 - options has an unknown property 'contentBase'. These properties are valid
```

According to [migration-v4](https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md)，`contentBase ` options were moved to `static` option.