### PR TITLE
feat: add example demoing MFE with React HMR support

### DIFF
--- a/react-hmr/README.md
+++ b/react-hmr/README.md
@@ -1,0 +1,37 @@
+# Module Federation with Webpack 5 in React
+
+This repo uses Webpack5 Module Federation plugin to build a React microfrontend
+
+## Get started
+
+```shell
+# Terminal 1
+cd packages/host
+npm i
+npm start
+
+# Terminal 2
+cd packages/remote1
+npm i
+npm start
+```
+
+With lerna
+
+```shell
+# make sure you have installed dependencies
+npm start
+```
+
+Host runs at http://localhost:3000 (live reload only)
+Remote1 runs at http://localhost:3001 (HMR supported)
+
+## How it works
+
+Host is the shell app which imports Remote1. Host is hosted on port 3000.
+
+Remote1 is hosted port 3001 and exposes 2 components Heading and Button.
+
+The exposed components are used in Host.
+
+The project also uses React Router to show that routing logic works just like a normal React app

--- a/react-hmr/host/package.json
+++ b/react-hmr/host/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "host",
+  "version": "1.0.0",
+  "description": "host application",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "webpack --mode production",
+    "start": "webpack serve"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.15.5",
+    "@babel/preset-react": "^7.14.5",
+    "babel-loader": "^8.2.2",
+    "external-remotes-plugin": "^1.0.0",
+    "html-webpack-plugin": "^5.3.2",
+    "webpack": "^5.52.0",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.2.0",
+    "webpack-livereload-plugin": "^3.0.2"
+  },
+  "dependencies": {}
+}

--- a/react-hmr/host/public/index.html
+++ b/react-hmr/host/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>HOST</title>
+    <script src="http://localhost:35729/livereload.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/react-hmr/host/src/App.js
+++ b/react-hmr/host/src/App.js
@@ -1,0 +1,57 @@
+import React, { Suspense } from "libs/react";
+import {
+  BrowserRouter as Router,
+  Switch,
+  Route,
+  Link,
+} from "libs/react-router-dom";
+
+import Heading from "remote1/Heading";
+
+const Button = React.lazy(() => import("remote1/Button"));
+
+const App = () => {
+  return (
+    <Router>
+      <div>
+        <div
+          style={{
+            margin: "10px",
+            padding: "10px",
+            textAlign: "center",
+            backgroundColor: "greenyellow",
+          }}
+        >
+          <h1>HOST</h1>
+          HOST ONLY SUPPORTS LIVE RELOAD. GO TO http://localhost:3001 to try out
+          HMR
+        </div>
+        <nav>
+          <ul>
+            <li>
+              <Link to="/">Home</Link>
+            </li>
+            <li>
+              <Link to="/button">Button</Link>
+            </li>
+            <li>
+              <Link to="/heading">Heading</Link>
+            </li>
+          </ul>
+        </nav>
+        <Suspense fallback={"loading..."}>
+          <Switch>
+            <Route path="/button">
+              <Button />
+            </Route>
+            <Route path="/heading">
+              <Heading />
+            </Route>
+          </Switch>
+        </Suspense>
+      </div>
+    </Router>
+  );
+};
+
+export default App;

--- a/react-hmr/host/src/bootstrap.js
+++ b/react-hmr/host/src/bootstrap.js
@@ -1,0 +1,5 @@
+import App from "./App";
+import React from "libs/react";
+import ReactDOM from "libs/react-dom";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/react-hmr/host/src/index.js
+++ b/react-hmr/host/src/index.js
@@ -1,0 +1,5 @@
+// Use dynamic import here to allow webpack to interface with module federation code
+window.remote1Url = "http://localhost:3001";
+window.libsUrl = "http://localhost:3002";
+
+import("./bootstrap");

--- a/react-hmr/host/webpack.config.js
+++ b/react-hmr/host/webpack.config.js
@@ -1,0 +1,54 @@
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { ModuleFederationPlugin } = require("webpack").container;
+const ExternalTemplateRemotesPlugin = require("external-remotes-plugin");
+const path = require("path");
+const LiveReloadPlugin = require("webpack-livereload-plugin");
+
+module.exports = {
+  entry: "./src/index",
+  mode: "development",
+  devtool: "source-map",
+  optimization: {
+    minimize: false,
+  },
+  devServer: {
+    hot: false,
+    static: path.join(__dirname, "dist"),
+    port: 3000,
+    historyApiFallback: {
+      index: "index.html",
+    },
+  },
+  output: {
+    publicPath: "auto",
+    clean: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        exclude: /node_modules/,
+        options: {
+          presets: ["@babel/preset-react"],
+        },
+      },
+    ],
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "host",
+      remotes: {
+        remote1: "remote1@[remote1Url]/remoteEntry.js",
+        libs: "libs@[libsUrl]/remoteEntry.js",
+      },
+    }),
+    new ExternalTemplateRemotesPlugin(),
+    new HtmlWebpackPlugin({
+      template: "./public/index.html",
+    }),
+    new LiveReloadPlugin({
+      port: 35729,
+    }),
+  ],
+};

--- a/react-hmr/lerna.json
+++ b/react-hmr/lerna.json
@@ -1,0 +1,4 @@
+{
+  "packages": ["host", "libs", "remote1"],
+  "version": "0.0.0"
+}

--- a/react-hmr/libs/package.json
+++ b/react-hmr/libs/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "libs",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "webpack --mode production",
+    "start": "webpack serve"
+  },
+  "dependencies": {
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
+    "react-router-dom": "^5.3.0"
+  },
+  "devDependencies": {
+    "webpack": "^5.52.1",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.2.0"
+  }
+}

--- a/react-hmr/libs/webpack.config.js
+++ b/react-hmr/libs/webpack.config.js
@@ -1,0 +1,25 @@
+const { ModuleFederationPlugin } = require("webpack").container;
+
+module.exports = {
+  entry: "./src/index",
+  mode: "development",
+  devServer: {
+    port: 3002,
+  },
+  output: {
+    publicPath: "auto",
+    clean: true,
+  },
+  module: {},
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "libs",
+      filename: "remoteEntry.js",
+      exposes: {
+        "./react": "react",
+        "./react-dom": "react-dom",
+        "./react-router-dom": "react-router-dom",
+      },
+    }),
+  ],
+};

--- a/react-hmr/package.json
+++ b/react-hmr/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "module-federation-with-react",
+  "version": "1.0.0",
+  "description": "experiments with module federation in React with Webpack5",
+  "main": "index.js",
+  "repository": "https://github.com/burhanuday/module-federation-with-react",
+  "author": "burhanuday",
+  "license": "MIT",
+  "private": false,
+  "devDependencies": {
+    "lerna": "^4.0.0"
+  },
+  "scripts": {
+    "start": "npx lerna run start --parallel"
+  }
+}

--- a/react-hmr/remote1/package.json
+++ b/react-hmr/remote1/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "remote1",
+  "version": "1.0.0",
+  "main": "dist/main.js",
+  "license": "MIT",
+  "scripts": {
+    "build": "webpack --mode production",
+    "start": "webpack serve"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.15.5",
+    "@babel/preset-react": "^7.14.5",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.0-rc.4",
+    "babel-loader": "^8.2.2",
+    "external-remotes-plugin": "^1.0.0",
+    "html-webpack-plugin": "^5.3.2",
+    "react-refresh": "^0.10.0",
+    "webpack": "^5.52.0",
+    "webpack-cli": "^4.8.0",
+    "webpack-dev-server": "^4.2.0"
+  },
+  "dependencies": {}
+}

--- a/react-hmr/remote1/public/index.html
+++ b/react-hmr/remote1/public/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>REMOTE1</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/react-hmr/remote1/src/App.js
+++ b/react-hmr/remote1/src/App.js
@@ -1,0 +1,16 @@
+import React, { useState } from "libs/react";
+
+const App = () => {
+  const [counter, setCounter] = useState(0);
+
+  return (
+    <main>
+      <h1>Remote 1's counter: {counter}</h1>
+      <button onClick={() => setCounter((counter) => counter + 1)}>
+        increment
+      </button>
+    </main>
+  );
+};
+
+export default App;

--- a/react-hmr/remote1/src/Button.js
+++ b/react-hmr/remote1/src/Button.js
@@ -1,0 +1,14 @@
+import React from "libs/react";
+import { useHistory } from "libs/react-router-dom";
+
+const Button = () => {
+  let history = useHistory();
+
+  function handleClick() {
+    history.push("/home");
+  }
+
+  return <button onClick={handleClick}>from remote1: GO HOME</button>;
+};
+
+export default Button;

--- a/react-hmr/remote1/src/Heading.js
+++ b/react-hmr/remote1/src/Heading.js
@@ -1,0 +1,7 @@
+import React from "libs/react";
+
+const Heading = () => {
+  return <h1>This is the heading</h1>;
+};
+
+export default Heading;

--- a/react-hmr/remote1/src/bootstrap.js
+++ b/react-hmr/remote1/src/bootstrap.js
@@ -1,0 +1,5 @@
+import App from "./App";
+import React from "libs/react";
+import ReactDOM from "libs/react-dom";
+
+ReactDOM.render(<App />, document.getElementById("root"));

--- a/react-hmr/remote1/src/index.js
+++ b/react-hmr/remote1/src/index.js
@@ -1,0 +1,3 @@
+window.libsUrl = "http://localhost:3002";
+
+import("./bootstrap");

--- a/react-hmr/remote1/webpack.config.js
+++ b/react-hmr/remote1/webpack.config.js
@@ -1,0 +1,58 @@
+const { ModuleFederationPlugin } = require("webpack").container;
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const ExternalTemplateRemotesPlugin = require("external-remotes-plugin");
+const path = require("path");
+const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
+
+module.exports = {
+  entry: "./src/index",
+  mode: "development",
+  devtool: "source-map",
+  optimization: {
+    minimize: false,
+  },
+  devServer: {
+    hot: true,
+    static: path.join(__dirname, "dist"),
+    port: 3001,
+    liveReload: false,
+  },
+  output: {
+    publicPath: "auto",
+    clean: true,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        loader: "babel-loader",
+        exclude: /node_modules/,
+        options: {
+          presets: ["@babel/preset-react"],
+          plugins: [require.resolve("react-refresh/babel")],
+        },
+      },
+    ],
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: "remote1",
+      filename: "remoteEntry.js",
+      exposes: {
+        "./Button": "./src/Button",
+        "./Heading": "./src/Heading",
+      },
+      remotes: {
+        libs: "libs@[libsUrl]/remoteEntry.js",
+      },
+    }),
+    new ExternalTemplateRemotesPlugin(),
+    new HtmlWebpackPlugin({
+      template: "./public/index.html",
+      chunks: ["main"],
+    }),
+    new ReactRefreshWebpackPlugin({
+      exclude: [/node_modules/, /bootstrap\.js$/],
+    }),
+  ],
+};


### PR DESCRIPTION
Added an example that shows how to achieve HMR in React
Note that HMR will only work in remotes and not in the Host app
The Host app still has liveReload functionality using the [Module Federation FMR plugin](https://www.npmjs.com/package/@module-federation/fmr)
For React HMR, fast refresh plugin is used
We also use ExternalTemplateRemotesPlugin for dynamic import urls of remotes