### PR TITLE
feat: Add vue2-in-vue3 example

### DIFF
--- a/vue2-in-vue3/README.md
+++ b/vue2-in-vue3/README.md
@@ -1,0 +1,10 @@
+# Vue3 use vue2 component Example
+
+This example demos a vue3 application loading remote vue2 component.`vue3` app depends on a component exposed by `vue2` app.
+
+# Running Demo
+
+Run `npm start` . This will build and serve both `vue3` and `vue2` on ports 3002 and 3001 respectively.
+
+- HOST (vue3): [localhost:3002](http://localhost:3002/)
+- REMOTE (vue2): [localhost:3001](http://localhost:3001/)

--- a/vue2-in-vue3/package.json
+++ b/vue2-in-vue3/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "lerna run --scope @vue2-in-vue3/* --parallel start",
+    "build": "lerna run --scope @vue2-in-vue3/* build",
+    "serve": "lerna run --scope @vue2-in-vue3/* --parallel serve",
+    "clean": "lerna run --scope @vue2-in-vue3/* --parallel clean"
+  },
+  "devDependencies": {
+    "lerna": "3.22.1"
+  }
+}

--- a/vue2-in-vue3/vue2/index.html
+++ b/vue2-in-vue3/vue2/index.html
@@ -1,0 +1,1 @@
+<div id="app"></div>

--- a/vue2-in-vue3/vue2/package.json
+++ b/vue2-in-vue3/vue2/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@vue2-in-vue3/vue2",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "start": "webpack-cli serve",
+    "serve": "serve dist -p 3001",
+    "build": "webpack --mode production",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@babel/core": "7.11.0",
+    "@vue/compiler-sfc": "3.2.6",
+    "babel-loader": "8.1.0",
+    "serve": "12.0.0",
+    "vue": "2.6.14"
+  },
+  "devDependencies": {
+    "css-loader": "6.2.0",
+    "file-loader": "6.2.0",
+    "html-webpack-plugin": "5.3.2",
+    "mini-css-extract-plugin": "2.3.0",
+    "url-loader": "4.1.1",
+    "vue-loader": "15.9.8",
+    "vue-template-compiler": "2.6.14",
+    "webpack": "5.52.1",
+    "webpack-cli": "4.8.0",
+    "webpack-dev-server": "4.2.0"
+  }
+}

--- a/vue2-in-vue3/vue2/src/App.vue
+++ b/vue2-in-vue3/vue2/src/App.vue
@@ -8,20 +8,16 @@
 
 <script>
 import Content from "./components/Content";
-import Button from './components/Button'
+import Button from './components/Button';
 
 export default {
-  // components: {
-  //   Content: defineAsyncComponent(() => import("./components/Content")),
-  //   Button: defineAsyncComponent(() => import("./components/Button")),
-  // },
   components: {
     Content,
     Button,
   },
   data() {
     return {
-      count: 0
+      count: 0,
     }
   },
   methods: {

--- a/vue2-in-vue3/vue2/src/App.vue
+++ b/vue2-in-vue3/vue2/src/App.vue
@@ -1,0 +1,39 @@
+<template>
+  <div>
+    <h3>Vue2 App</h3>
+    <Content :count="count"/>
+    <Button @btnClick="inc"/>
+  </div>
+</template>
+
+<script>
+import Content from "./components/Content";
+import Button from './components/Button'
+
+export default {
+  // components: {
+  //   Content: defineAsyncComponent(() => import("./components/Content")),
+  //   Button: defineAsyncComponent(() => import("./components/Button")),
+  // },
+  components: {
+    Content,
+    Button,
+  },
+  data() {
+    return {
+      count: 0
+    }
+  },
+  methods: {
+    inc() {
+      this.count++;
+    }
+  }
+};
+</script>
+
+<style scoped>
+h1 {
+  font-family: Arial, Helvetica, sans-serif;
+}
+</style>

--- a/vue2-in-vue3/vue2/src/components/Button.vue
+++ b/vue2-in-vue3/vue2/src/components/Button.vue
@@ -7,9 +7,9 @@
 export default {
   methods: {
     click() {
-      this.$emit("btnClick")
+      this.$emit("btnClick");
       // vue3 events needs the Camel-Case start with "on"
-      this.$emit("onBtnClick")
+      this.$emit("onBtnClick");
     }
   }
 }

--- a/vue2-in-vue3/vue2/src/components/Button.vue
+++ b/vue2-in-vue3/vue2/src/components/Button.vue
@@ -1,0 +1,17 @@
+<template>
+  <button @click="click">vue2 button click</button>
+</template>
+
+<script>
+
+export default {
+  methods: {
+    click() {
+      this.$emit("btnClick")
+      // vue3 events needs the Camel-Case start with "on"
+      this.$emit("onBtnClick")
+    }
+  }
+}
+</script>
+

--- a/vue2-in-vue3/vue2/src/components/Content.vue
+++ b/vue2-in-vue3/vue2/src/components/Content.vue
@@ -1,0 +1,17 @@
+<template>
+  <div style="color: red;">
+    {{ title }}
+    <div>count: {{ count }}</div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['count'],
+  data() {
+    return {
+      title: "Component in Action..",
+    };
+  },
+};
+</script>

--- a/vue2-in-vue3/vue2/src/main.js
+++ b/vue2-in-vue3/vue2/src/main.js
@@ -1,0 +1,6 @@
+import Vue from 'vue';
+import App from './App.vue';
+
+new Vue({
+  render: (h) => h(App),
+}).$mount("#app");

--- a/vue2-in-vue3/vue2/webpack.config.js
+++ b/vue2-in-vue3/vue2/webpack.config.js
@@ -1,0 +1,73 @@
+const path = require("path");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { VueLoaderPlugin } = require('vue-loader');
+const { ModuleFederationPlugin } = require("webpack").container;
+module.exports = (env = {}) => ({
+  mode: "development",
+  cache: false,
+  devtool: "source-map",
+  optimization: {
+    minimize: false,
+  },
+  entry: path.resolve(__dirname, "./src/main.js"),
+  output: {
+    publicPath: "auto",
+  },
+  resolve: {
+    extensions: [".vue", ".jsx", ".js", ".json"],
+    alias: {
+      vue$: 'vue/dist/vue.common.js',
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        use: "vue-loader",
+      },
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {},
+          },
+          "css-loader",
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new VueLoaderPlugin(),
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+    }),
+    new ModuleFederationPlugin({
+      name: "vue2App",
+      filename: "remoteEntry.js",
+      library: { type: 'var', name: 'vue2App' },
+      exposes: {
+        "./vue2": "./node_modules/vue/dist/vue",
+        "./Button": "./src/components/Button",
+      },
+    }),
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, "./index.html"),
+    })
+  ],
+  devServer: {
+    static: {
+      directory: path.join(__dirname),
+    },
+    compress: true,
+    port: 3001,
+    hot: true,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "X-Requested-With, content-type, Authorization",
+    },
+  },
+});

--- a/vue2-in-vue3/vue3/index.html
+++ b/vue2-in-vue3/vue3/index.html
@@ -1,0 +1,1 @@
+<div id="app"></div>

--- a/vue2-in-vue3/vue3/package.json
+++ b/vue2-in-vue3/vue3/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@vue2-in-vue3/vue3",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "start": "webpack-cli serve",
+    "serve": "serve dist -p 3002",
+    "build": "webpack --mode production",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@babel/core": "7.11.0",
+    "@vue/compiler-sfc": "3.2.6",
+    "babel-loader": "8.1.0",
+    "serve": "12.0.0",
+    "vue": "3.2.11"
+  },
+  "devDependencies": {
+    "@vue/compiler-sfc": "3.2.6",
+    "css-loader": "6.2.0",
+    "file-loader": "6.2.0",
+    "html-webpack-plugin": "5.3.2",
+    "mini-css-extract-plugin": "2.3.0",
+    "url-loader": "4.1.1",
+    "vue-loader": "16.5.0",
+    "webpack": "5.52.1",
+    "webpack-cli": "4.8.0",
+    "webpack-dev-server": "4.2.0"
+  }
+}

--- a/vue2-in-vue3/vue3/src/App.vue
+++ b/vue2-in-vue3/vue3/src/App.vue
@@ -1,0 +1,41 @@
+<template>
+  <div>
+    <h3>Vue3 App</h3>
+    <Content :count="count"/>
+    
+    <div id="vue2Button"></div>
+    <vue2-button @btnClick="inc"/>
+    
+  </div>
+</template>
+
+<script>
+import { ref } from "vue";
+import Content from "./components/Content";
+import { vue2ToVue3 } from './utils';
+import Button from 'vue2App/Button';
+
+export default {
+  components: {
+    Content,
+    vue2Button: vue2ToVue3(Button, 'vue2Button'),
+  },
+  setup() {
+    const count = ref(0);
+    const inc = () => {
+      count.value++;
+    };
+
+    return {
+      count,
+      inc
+    };
+  }
+};
+</script>
+
+<style scoped>
+h1 {
+  font-family: Arial, Helvetica, sans-serif;
+}
+</style>

--- a/vue2-in-vue3/vue3/src/App.vue
+++ b/vue2-in-vue3/vue3/src/App.vue
@@ -28,7 +28,7 @@ export default {
 
     return {
       count,
-      inc
+      inc,
     };
   }
 };

--- a/vue2-in-vue3/vue3/src/bootstrap.js
+++ b/vue2-in-vue3/vue3/src/bootstrap.js
@@ -1,0 +1,4 @@
+import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount('#app');

--- a/vue2-in-vue3/vue3/src/components/Content.vue
+++ b/vue2-in-vue3/vue3/src/components/Content.vue
@@ -1,0 +1,17 @@
+<template>
+  <div style="color: red;">
+    {{ title }}
+    <div>count: {{ count }}</div>
+  </div>
+</template>
+
+<script>
+export default {
+  props: ['count'],
+  data() {
+    return {
+      title: "Remote Component in Action..",
+    };
+  },
+};
+</script>

--- a/vue2-in-vue3/vue3/src/main.js
+++ b/vue2-in-vue3/vue3/src/main.js
@@ -1,0 +1,2 @@
+
+import("./bootstrap");

--- a/vue2-in-vue3/vue3/src/utils/index.js
+++ b/vue2-in-vue3/vue3/src/utils/index.js
@@ -1,0 +1,41 @@
+import Vue2 from 'vue2App/vue2';
+
+function bindSlotContext(target = {}, context) {
+  return Object.keys(target).map(key => {
+      const vnode = target[key];
+      vnode.context = context;
+      return vnode;
+  });
+}
+
+
+/*
+ * Transform vue2 components to DOM.
+*/
+export function vue2ToVue3(WrapperComponent, wrapperId) {
+  let vm;
+  return {
+    mounted() {
+      const slots = bindSlotContext(this.$slots, this.__self);
+      vm = new Vue2({
+        render: createElement => {
+          return createElement(
+            WrapperComponent,
+            {
+              on: this.$attrs,
+              attrs: this.$attrs,
+              props: this.$props,
+              scopedSlots: this.$scopedSlots,
+            },
+            slots
+          )
+        }
+      });
+      vm.$mount(`#${wrapperId}`);
+    },
+    props: WrapperComponent.props,
+    render() {
+      vm && vm.$forceUpdate();
+    }
+  }
+}

--- a/vue2-in-vue3/vue3/webpack.config.js
+++ b/vue2-in-vue3/vue3/webpack.config.js
@@ -1,0 +1,82 @@
+const path = require("path");
+const { VueLoaderPlugin } = require("vue-loader");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const { ModuleFederationPlugin } = require("webpack").container;
+module.exports = (env = {}) => ({
+  mode: "development",
+  cache: false,
+  devtool: "source-map",
+  optimization: {
+    minimize: false,
+  },
+  entry: path.resolve(__dirname, "./src/main.js"),
+  output: {
+    publicPath: "auto",
+  },
+  resolve: {
+    extensions: [".vue", ".jsx", ".js", ".json"],
+    alias: {
+      // this isn't technically needed, since the default `vue` entry for bundlers
+      // is a simple `export * from '@vue/runtime-dom`. However having this
+      // extra re-export somehow causes webpack to always invalidate the module
+      // on the first HMR update and causes the page to reload.
+      vue: "@vue/runtime-dom",
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        use: "vue-loader",
+      },
+      {
+        test: /\.png$/,
+        use: {
+          loader: "url-loader",
+          options: { limit: 8192 },
+        },
+      },
+      {
+        test: /\.css$/,
+        use: [
+          {
+            loader: MiniCssExtractPlugin.loader,
+            options: {},
+          },
+          "css-loader",
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new VueLoaderPlugin(),
+    new MiniCssExtractPlugin({
+      filename: "[name].css",
+    }),
+    new ModuleFederationPlugin({
+      name: "vue3",
+      filename: "remoteEntry.js",
+      remotes: {
+        vue2App: "vue2App@http://localhost:3001/remoteEntry.js",
+      },
+    }),
+    new HtmlWebpackPlugin({
+      template: path.resolve(__dirname, "./index.html"),
+    }),
+  ],
+  devServer: {
+    static: {
+      directory: path.join(__dirname),
+    },
+    compress: true,
+    port: 3002,
+    hot: true,
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, PATCH, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "X-Requested-With, content-type, Authorization",
+    },
+  },
+});


### PR DESCRIPTION
New example demos a vue3 application loading remote vue2 component.`vue3` app depends on a component exposed by `vue2` app.