### PR TITLE
Fix angular lazy components federation in production

### DIFF
--- a/angular11-microfrontends-lazy-components/package.json
+++ b/angular11-microfrontends-lazy-components/package.json
@@ -54,6 +54,6 @@
     "protractor": "7.0.0",
     "ts-node": "9.1.1",
     "tslint": "6.1.3",
-    "typescript": "4.3.5"
+    "typescript": "4.1.6"
   }
 }

--- a/angular11-microfrontends-lazy-components/projects/mdmf-profile/src/app/profile/components/list-user/list-user.component.ts
+++ b/angular11-microfrontends-lazy-components/projects/mdmf-profile/src/app/profile/components/list-user/list-user.component.ts
@@ -9,6 +9,7 @@ import { Observable } from "rxjs";
   selector: "app-profile-list-user",
   templateUrl: "./list-user.component.html",
   styleUrls: ["./list-user.component.css"],
+  exportAs: 'ListUserComponent'
 })
 export class ListUserComponent implements OnInit {
   @Select(UserState.getUsers) users: Observable<User[]>;

--- a/angular11-microfrontends-lazy-components/projects/mdmf-profile/src/app/profile/profile.module.ts
+++ b/angular11-microfrontends-lazy-components/projects/mdmf-profile/src/app/profile/profile.module.ts
@@ -10,8 +10,12 @@ import { ProfileRoutingModule } from "./profile-routing.module";
 import { ProfileComponent } from "./components/profile/profile.component";
 import { ListUserComponent } from "./components/list-user/list-user.component";
 
+const EXPORTS = [
+  ListUserComponent
+];
+
 @NgModule({
-  declarations: [ProfileComponent, ListUserComponent],
+  declarations: [ProfileComponent, ...EXPORTS],
   imports: [
     CommonModule,
     ProfileRoutingModule,
@@ -21,6 +25,8 @@ import { ListUserComponent } from "./components/list-user/list-user.component";
     ReactiveFormsModule,
     MdmfSharedModule,
   ],
-  exports: [ListUserComponent],
+  exports: [...EXPORTS],
 })
-export class ProfileModule {}
+export class ProfileModule {
+  static exports = EXPORTS; // prevents from components being tree-shaked in production
+}

--- a/angular11-microfrontends-lazy-components/projects/mdmf-shell/src/app/shell/components/federated/federated.component.ts
+++ b/angular11-microfrontends-lazy-components/projects/mdmf-shell/src/app/shell/components/federated/federated.component.ts
@@ -34,8 +34,8 @@ export class FederatedComponent implements OnInit {
       exposedModule: this.exposedModule,
     }).then((federated) => {
       const componentFactory = this.cfr.resolveComponentFactory(
-        federated[this.exposedModule].ɵmod.exports.find(
-          (e) => e.name === this.componentName
+        federated[this.exposedModule].exports.find(
+          (e) => e.ɵcmp.exportAs[0] === this.componentName
         )
       );
       const { instance } = this.federatedComponent.createComponent(

--- a/angular11-microfrontends-lazy-components/projects/mdmf-shell/src/app/shell/components/federated/federated.component.ts
+++ b/angular11-microfrontends-lazy-components/projects/mdmf-shell/src/app/shell/components/federated/federated.component.ts
@@ -35,7 +35,7 @@ export class FederatedComponent implements OnInit {
     }).then((federated) => {
       const componentFactory = this.cfr.resolveComponentFactory(
         federated[this.exposedModule].exports.find(
-          (e) => e.ɵcmp.exportAs[0] === this.componentName
+          (e) => e.ɵcmp?.exportAs[0] === this.componentName
         )
       );
       const { instance } = this.federatedComponent.createComponent(

--- a/angular11-microfrontends-lazy-components/projects/mdmf-shell/src/app/utils/federation-utils.ts
+++ b/angular11-microfrontends-lazy-components/projects/mdmf-shell/src/app/utils/federation-utils.ts
@@ -12,7 +12,7 @@ declare const __webpack_share_scopes__: { default: Scope };
 const moduleMap = {};
 
 function loadRemoteEntry(remoteEntry: string): Promise<void> {
-  return new Promise<any>((resolve, reject) => {
+  return new Promise<void>((resolve, reject) => {
     if (moduleMap[remoteEntry]) {
       resolve();
       return;

--- a/angular11-microfrontends-lazy-components/yarn.lock
+++ b/angular11-microfrontends-lazy-components/yarn.lock
@@ -9814,10 +9814,10 @@ typescript@4.1.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
   integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
 
-typescript@4.3.5:
-  version "4.3.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.3.5.tgz#4d1c37cc16e893973c45a06886b7113234f119f4"
-  integrity sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==
+typescript@4.1.6:
+  version "4.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.6.tgz#1becd85d77567c3c741172339e93ce2e69932138"
+  integrity sha512-pxnwLxeb/Z5SP80JDRzVjh58KsM6jZHRAOtTpS7sXLS4ogXNKC9ANxHHZqLLeVHZN35jCtI4JdmLLbLiC1kBow==
 
 ua-parser-js@^0.7.28:
   version "0.7.28"


### PR DESCRIPTION
Fixed angular11-lazy-components federation in production mode. Components were not federated correctly in production mode due to AOT compilation which was tree-shaking components marked as "unused". Also fixed typescript dependency because Angular 11 only support version < 4.2.0.

Fixes https://github.com/module-federation/module-federation-examples/issues/938.