### PR TITLE
Change private setting in react-hmr package.json from false to true

### DIFF
--- a/react-hmr/package.json
+++ b/react-hmr/package.json
@@ -6,7 +6,7 @@
   "repository": "https://github.com/burhanuday/module-federation-with-react",
   "author": "burhanuday",
   "license": "MIT",
-  "private": false,
+  "private": true,
   "workspaces": {
     "packages": [
       "host", "libs", "remote1"


### PR DESCRIPTION
Fix `error Workspaces can only be enabled in private projects.` error.