### PR TITLE
Bump webpack-cli to 4.9.1 in react-hmr example

### DIFF
--- a/react-hmr/host/package.json
+++ b/react-hmr/host/package.json
@@ -15,7 +15,7 @@
     "external-remotes-plugin": "1.0.0",
     "html-webpack-plugin": "5.3.2",
     "webpack": "5.61.0",
-    "webpack-cli": "4.8.0",
+    "webpack-cli": "4.9.1",
     "webpack-dev-server": "4.2.1",
     "webpack-livereload-plugin": "3.0.2"
   },

--- a/react-hmr/libs/package.json
+++ b/react-hmr/libs/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "webpack": "5.61.0",
-    "webpack-cli": "4.8.0",
+    "webpack-cli": "4.9.1",
     "webpack-dev-server": "4.2.1"
   }
 }

--- a/react-hmr/remote1/package.json
+++ b/react-hmr/remote1/package.json
@@ -16,7 +16,7 @@
     "html-webpack-plugin": "5.3.2",
     "react-refresh": "0.10.0",
     "webpack": "5.61.0",
-    "webpack-cli": "4.8.0",
+    "webpack-cli": "4.9.1",
     "webpack-dev-server": "4.2.1"
   },
   "dependencies": {}


### PR DESCRIPTION
It's the fix for the following problem:
```
[0] [webpack-cli] Unable to load '@webpack-cli/serve' command
[0] [webpack-cli] TypeError: options.forEach is not a function
```
https://github.com/webpack/webpack-cli/issues/2990#issuecomment-937704258