### PR TITLE
Fixed build for vue 3 demo

### DIFF
--- a/vue3-demo/home/package.json
+++ b/vue3-demo/home/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.11.0",
-    "@vue/compiler-sfc": "3.2.26",
     "babel-loader": "^8.1.0",
     "serve": "^12.0.0",
     "vue": "^3.0.11"

--- a/vue3-demo/home/package.json
+++ b/vue3-demo/home/package.json
@@ -24,7 +24,7 @@
     "url-loader": "4.1.1",
     "vue-loader": "16.8.3",
     "webpack": "5.66.0",
-    "webpack-cli": "4.8.0",
+    "webpack-cli": "4.9.1",
     "webpack-dev-server": "4.7.3"
   }
 }

--- a/vue3-demo/layout/package.json
+++ b/vue3-demo/layout/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "@babel/core": "^7.11.0",
-    "@vue/compiler-sfc": "^3.0.11",
     "babel-loader": "^8.1.0",
     "serve": "^12.0.0",
     "vue": "^3.0.11"

--- a/vue3-demo/layout/package.json
+++ b/vue3-demo/layout/package.json
@@ -24,7 +24,7 @@
     "url-loader": "4.1.1",
     "vue-loader": "16.8.3",
     "webpack": "5.66.0",
-    "webpack-cli": "4.8.0",
+    "webpack-cli": "4.9.1",
     "webpack-dev-server": "4.7.3"
   }
 }


### PR DESCRIPTION
Error: Unable to load '@webpack-cli/serve' command

Fix: updated webpack cli (from https://github.com/webpack/webpack-cli/issues/2990)

And removed duplicated dependencies (a problem when versions are different and build down)