### PR TITLE
FIX ng serve with angular-13 example

### DIFF
--- a/angular13-microfrontends-lazy-components/package.json
+++ b/angular13-microfrontends-lazy-components/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start:shell": "ng serve",
+    "start:shell": "ng serve --live-reload false",
     "start:profile": "ng serve mdmf-profile",
     "build:shared": "ng build mdmf-shared",
     "build:shell": "ng build mdmf-shell --prod",


### PR DESCRIPTION
Added  ' --live-reload false' to ' "start:shell": "ng serve" ' script in package.json because live-reload is broken in this example. Without the ' --live-reload false' the apps is reloading infinitelly on 'ng serve'.