### PR TITLE
Get rid of bundle-loader in basic-host-example

### DIFF
--- a/basic-host-remote/app1/package.json
+++ b/basic-host-remote/app1/package.json
@@ -6,7 +6,6 @@
     "@babel/core": "7.17.5",
     "@babel/preset-react": "7.16.7",
     "babel-loader": "8.2.3",
-    "bundle-loader": "0.5.6",
     "html-webpack-plugin": "5.5.0",
     "serve": "13.0.2",
     "webpack": "5.66.0",

--- a/basic-host-remote/app1/src/index.js
+++ b/basic-host-remote/app1/src/index.js
@@ -1,2 +1,1 @@
-import bootstrap from './bootstrap';
-bootstrap(() => {});
+import('./bootstrap');

--- a/basic-host-remote/app1/webpack.config.js
+++ b/basic-host-remote/app1/webpack.config.js
@@ -17,13 +17,6 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /bootstrap\.js$/,
-        loader: 'bundle-loader',
-        options: {
-          lazy: true,
-        },
-      },
-      {
         test: /\.jsx?$/,
         loader: 'babel-loader',
         exclude: /node_modules/,

--- a/basic-host-remote/yarn.lock
+++ b/basic-host-remote/yarn.lock
@@ -2080,13 +2080,6 @@ builtins@^1.0.3:
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
 
-bundle-loader@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/bundle-loader/-/bundle-loader-0.5.6.tgz#6c9042e62f1c89941458805a3a479d10f34c71fd"
-  integrity sha512-SUgX+u/LJzlJiuoIghuubZ66eflehnjmqSfh/ib9DTe08sxRJ5F/MhHSjp7GfSJivSp8NWgez4PVNAUuMg7vSg==
-  dependencies:
-    loader-utils "^1.1.0"
-
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -4771,7 +4764,7 @@ loader-runner@^4.2.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
-loader-utils@^1.1.0, loader-utils@^1.4.0:
+loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==


### PR DESCRIPTION
`bundle-loader` is deprecated.