### PR TITLE
fix: Compilation error when starting vue2-in-vue3 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ This repository is to showcase examples of how Webpack 5's new Module Federation
 - [x] [NextJS SSR](./nextjs-ssr/README.md) &mdash; Powered by software streams, with [nextjs-ssr](https://github.com/module-federation/module-federation-examples/tree/master/nextjs-ssr) (currently in closed beta testing)
 - [x] [Building A Plugin-based Workflow Designer With Angular and Module Federation](https://github.com/manfredsteyer/module-federation-with-angular-dynamic-workflow-designer) &mdash; External Example
 - [x] [Vue.js](./vue3-demo/README.md) &mdash; Simple host/remote (render function / sfc) example using Vue 3.0.
+- [x] [Vue 2 in Vue 3](./vue2-in-vue3/README.md) &mdash; Vue 3 application loading remote Vue 2 component.
 - [x] [Vue2 SSR](./genesis/README.md) &mdash; This example demonstrates module as a service
 
 # Check out our book

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
       "./advanced-api/dynamic-remotes/*",
       "./advanced-api/automatic-vendor-sharing/*",
       "./nextjs-bi-directional/*",
+      "./vue2-in-vue3/*",
       "./vue3-demo/*",
       "./vue-cli/*",
       "./genesis/*"

--- a/vue2-in-vue3/README.md
+++ b/vue2-in-vue3/README.md
@@ -4,7 +4,7 @@ This example demos a vue3 application loading remote vue2 component.`vue3` app d
 
 # Running Demo
 
-Run `npm start` . This will build and serve both `vue3` and `vue2` on ports 3002 and 3001 respectively.
+Run `yarn start` . This will build and serve both `vue3` and `vue2` on ports 3002 and 3001 respectively.
 
 - HOST (vue3): [localhost:3002](http://localhost:3002/)
 - REMOTE (vue2): [localhost:3001](http://localhost:3001/)

--- a/vue2-in-vue3/vue2/package.json
+++ b/vue2-in-vue3/vue2/package.json
@@ -26,5 +26,10 @@
     "webpack": "5.70.0",
     "webpack-cli": "4.9.2",
     "webpack-dev-server": "4.8.1"
+  },
+  "workspaces": {
+    "nohoist": [
+      "**"
+    ]
   }
 }

--- a/vue2-in-vue3/vue3/package.json
+++ b/vue2-in-vue3/vue3/package.json
@@ -26,5 +26,10 @@
     "webpack": "5.70.0",
     "webpack-cli": "4.9.2",
     "webpack-dev-server": "4.8.1"
+  },
+  "workspaces": {
+    "nohoist": [
+      "**"
+    ]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5720,6 +5720,13 @@
   dependencies:
     "@vue/shared" "3.0.11"
 
+"@vue/reactivity@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.33.tgz#c84eedb5225138dbfc2472864c151d3efbb4b673"
+  integrity sha512-62Sq0mp9/0bLmDuxuLD5CIaMG2susFAGARLuZ/5jkU1FCf9EDbwUuF+BO8Ub3Rbodx0ziIecM/NsmyjardBxfQ==
+  dependencies:
+    "@vue/shared" "3.2.33"
+
 "@vue/reactivity@^3.2.27":
   version "3.2.31"
   resolved "https://registry.yarnpkg.com/@vue/reactivity/-/reactivity-3.2.31.tgz#fc90aa2cdf695418b79e534783aca90d63a46bbd"
@@ -5735,6 +5742,14 @@
     "@vue/reactivity" "3.0.11"
     "@vue/shared" "3.0.11"
 
+"@vue/runtime-core@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-core/-/runtime-core-3.2.33.tgz#2df8907c85c37c3419fbd1bdf1a2df097fa40df2"
+  integrity sha512-N2D2vfaXsBPhzCV3JsXQa2NECjxP3eXgZlFqKh4tgakp3iX6LCGv76DLlc+IfFZq+TW10Y8QUfeihXOupJ1dGw==
+  dependencies:
+    "@vue/reactivity" "3.2.33"
+    "@vue/shared" "3.2.33"
+
 "@vue/runtime-dom@3.0.11":
   version "3.0.11"
   resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.0.11.tgz#7a552df21907942721feb6961c418e222a699337"
@@ -5743,6 +5758,23 @@
     "@vue/runtime-core" "3.0.11"
     "@vue/shared" "3.0.11"
     csstype "^2.6.8"
+
+"@vue/runtime-dom@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/runtime-dom/-/runtime-dom-3.2.33.tgz#123b8969247029ea0d9c1983676d4706a962d848"
+  integrity sha512-LSrJ6W7CZTSUygX5s8aFkraDWlO6K4geOwA3quFF2O+hC3QuAMZt/0Xb7JKE3C4JD4pFwCSO7oCrZmZ0BIJUnw==
+  dependencies:
+    "@vue/runtime-core" "3.2.33"
+    "@vue/shared" "3.2.33"
+    csstype "^2.6.8"
+
+"@vue/server-renderer@3.2.33":
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/@vue/server-renderer/-/server-renderer-3.2.33.tgz#4b45d6d2ae10ea4e3d2cf8e676804cf60f331979"
+  integrity sha512-4jpJHRD4ORv8PlbYi+/MfP8ec1okz6rybe36MdpkDrGIdEItHEUyaHSKvz+ptNEyQpALmmVfRteHkU9F8vxOew==
+  dependencies:
+    "@vue/compiler-ssr" "3.2.33"
+    "@vue/shared" "3.2.33"
 
 "@vue/shared@3.0.11":
   version "3.0.11"
@@ -22257,6 +22289,17 @@ vue@2.6.14, vue@^2.6.14:
   version "2.6.14"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.14.tgz#e51aa5250250d569a3fbad3a8a5a687d6036e235"
   integrity sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==
+
+vue@3.2.33:
+  version "3.2.33"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.33.tgz#7867eb16a3293a28c4d190a837bc447878bd64c2"
+  integrity sha512-si1ExAlDUrLSIg/V7D/GgA4twJwfsfgG+t9w10z38HhL/HA07132pUQ2KuwAo8qbCyMJ9e6OqrmWrOCr+jW7ZQ==
+  dependencies:
+    "@vue/compiler-dom" "3.2.33"
+    "@vue/compiler-sfc" "3.2.33"
+    "@vue/runtime-dom" "3.2.33"
+    "@vue/server-renderer" "3.2.33"
+    "@vue/shared" "3.2.33"
 
 vue@^2.6.11:
   version "2.6.12"


### PR DESCRIPTION
I first tried to run `yarn install` at the root level then `cd` into `vue2-in-vue3` and run `yarn start`, but `lerna` was not finding any packages when scoping `@vue2-in-vue3/*`. I added `"./vue2-in-vue3/*",` to `workspaces.packages` in the root package.json to fix that, but I got a compilation error afterwards (vue-loader complaining about version mismatch). Adding `workspaces.nohoist` to both packages inside `vue2-in-vue3` was the only way of having the start script running without any error.

```json
"workspaces": {
  "nohoist": [
    "**"
  ]
}
```

This `vue2-in-vue3` example is great! We should make sure people are able to run it 😉 