### PR TITLE
Add Typescript Project References example

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
       "./shared-routing/*",
       "./shared-routes2/*",
       "./typescript/*",
+      "./typescript-project-references/*",
       "./nested/*",
       "./nextjs-sidecar/*",
       "./version-discrepancy/*",

--- a/typescript-project-references/README.md
+++ b/typescript-project-references/README.md
@@ -1,0 +1,11 @@
+# TypeScript Project References Example
+
+This example demos a basic host/remote application with TypeScript using [Project References](https://www.typescriptlang.org/docs/handbook/project-references.html).
+
+# Running Demo
+
+Run `yarn start`. This will build and serve both `app1` and `app2` on ports 3001 and 3002 respectively.
+
+- [localhost:3001](http://localhost:3001/)
+- [localhost:3002](http://localhost:3002/)
+  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/TypeScriptProjectReferences">

--- a/typescript-project-references/app1/package.json
+++ b/typescript-project-references/app1/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@typescript-project-references/app1",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "7.17.10",
+    "@babel/preset-react": "7.16.7",
+    "@babel/preset-typescript": "7.16.7",
+    "@types/react": "17.0.45",
+    "@types/react-dom": "17.0.17",
+    "babel-loader": "8.2.5",
+    "html-webpack-plugin": "5.5.0",
+    "serve": "13.0.2",
+    "tsconfig-paths-webpack-plugin": "3.5.2",
+    "typescript": "4.3.5",
+    "webpack": "5.72.1",
+    "webpack-cli": "4.9.2",
+    "webpack-dev-server": "4.8.1"
+  },
+  "scripts": {
+    "start": "webpack-cli serve",
+    "build": "webpack --mode production",
+    "serve": "serve dist -p 3001",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0"
+  }
+}

--- a/typescript-project-references/app1/public/index.html
+++ b/typescript-project-references/app1/public/index.html
@@ -1,0 +1,6 @@
+<html>
+  <head> </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/typescript-project-references/app1/src/App.tsx
+++ b/typescript-project-references/app1/src/App.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+
+const RemoteButton = React.lazy(() => import('app2/Button'));
+
+const App = () => (
+  <div>
+    <h1>Typescript</h1>
+    <h2>App 1</h2>
+    <React.Suspense fallback="Loading Button">
+      <RemoteButton />
+    </React.Suspense>
+  </div>
+);
+
+export default App;

--- a/typescript-project-references/app1/src/bootstrap.tsx
+++ b/typescript-project-references/app1/src/bootstrap.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import App from './App';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/typescript-project-references/app1/src/index.tsx
+++ b/typescript-project-references/app1/src/index.tsx
@@ -1,0 +1,1 @@
+import('./bootstrap');

--- a/typescript-project-references/app1/tsconfig.json
+++ b/typescript-project-references/app1/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.base.json",
+  "references": [
+    { "path": "../app2" }
+  ],
+  "include": ["src"]
+}

--- a/typescript-project-references/app1/webpack.config.js
+++ b/typescript-project-references/app1/webpack.config.js
@@ -1,0 +1,46 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ModuleFederationPlugin = require('webpack').container.ModuleFederationPlugin;
+const path = require('path');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
+module.exports = {
+  entry: './src/index',
+  mode: 'development',
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'dist'),
+    },
+    port: 3001,
+  },
+  output: {
+    publicPath: 'auto',
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+    plugins: [new TsconfigPathsPlugin()]
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        options: {
+          presets: ['@babel/preset-react', '@babel/preset-typescript'],
+        },
+      },
+    ],
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'app1',
+      remotes: {
+        app2: 'app2@http://localhost:3002/remoteEntry.js',
+      },
+      shared: ['react', 'react-dom'],
+    }),
+    new HtmlWebpackPlugin({
+      template: './public/index.html',
+    }),
+  ],
+};

--- a/typescript-project-references/app2/package.json
+++ b/typescript-project-references/app2/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@typescript-project-references/app2",
+  "version": "0.0.0",
+  "private": true,
+  "devDependencies": {
+    "@babel/core": "7.17.10",
+    "@babel/preset-react": "7.16.7",
+    "@babel/preset-typescript": "7.16.7",
+    "@types/react": "17.0.45",
+    "@types/react-dom": "17.0.17",
+    "babel-loader": "8.2.5",
+    "html-webpack-plugin": "5.5.0",
+    "serve": "13.0.2",
+    "tsconfig-paths-webpack-plugin": "3.5.2",
+    "typescript": "4.3.5",
+    "webpack": "5.72.1",
+    "webpack-cli": "4.9.2",
+    "webpack-dev-server": "4.8.1"
+  },
+  "scripts": {
+    "start": "webpack-cli serve",
+    "build": "webpack --mode production",
+    "serve": "serve dist -p 3002",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "react": "^16.13.0",
+    "react-dom": "^16.13.0"
+  }
+}

--- a/typescript-project-references/app2/public/index.html
+++ b/typescript-project-references/app2/public/index.html
@@ -1,0 +1,5 @@
+<html>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/typescript-project-references/app2/src/App.tsx
+++ b/typescript-project-references/app2/src/App.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+
+import LocalButton from './Button';
+
+const App = () => (
+  <div>
+    <h1>Typescript</h1>
+    <h2>App 2</h2>
+    <LocalButton />
+  </div>
+);
+
+export default App;

--- a/typescript-project-references/app2/src/Button.tsx
+++ b/typescript-project-references/app2/src/Button.tsx
@@ -1,0 +1,5 @@
+import * as React from 'react';
+
+const Button = () => <button>App 2 Button</button>;
+
+export default Button;

--- a/typescript-project-references/app2/src/bootstrap.tsx
+++ b/typescript-project-references/app2/src/bootstrap.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+
+import App from './App';
+
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/typescript-project-references/app2/src/index.tsx
+++ b/typescript-project-references/app2/src/index.tsx
@@ -1,0 +1,1 @@
+import('./bootstrap');

--- a/typescript-project-references/app2/tsconfig.json
+++ b/typescript-project-references/app2/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/typescript-project-references/app2/webpack.config.js
+++ b/typescript-project-references/app2/webpack.config.js
@@ -1,0 +1,47 @@
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ModuleFederationPlugin = require('webpack').container.ModuleFederationPlugin;
+const path = require('path');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
+
+module.exports = {
+  entry: './src/index',
+  mode: 'development',
+  devServer: {
+    static: {
+      directory: path.join(__dirname, 'dist'),
+    },
+    port: 3002,
+  },
+  output: {
+    publicPath: 'auto',
+  },
+  resolve: {
+    extensions: ['.ts', '.tsx', '.js'],
+    plugins: [new TsconfigPathsPlugin()]
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        loader: 'babel-loader',
+        exclude: /node_modules/,
+        options: {
+          presets: ['@babel/preset-react', '@babel/preset-typescript'],
+        },
+      },
+    ],
+  },
+  plugins: [
+    new ModuleFederationPlugin({
+      name: 'app2',
+      filename: 'remoteEntry.js',
+      exposes: {
+        './Button': './src/Button',
+      },
+      shared: ['react', 'react-dom'],
+    }),
+    new HtmlWebpackPlugin({
+      template: './public/index.html',
+    }),
+  ],
+};

--- a/typescript-project-references/package.json
+++ b/typescript-project-references/package.json
@@ -1,0 +1,12 @@
+{
+  "private": true,
+  "scripts": {
+    "start": "lerna run --scope @typescript-project-references/* --parallel start",
+    "build": "lerna run --scope @typescript-project-references/* build",
+    "serve": "lerna run --scope @typescript-project-references/* --parallel serve",
+    "clean": "lerna run --scope @typescript-project-references/* --parallel clean"
+  },
+  "devDependencies": {
+    "lerna": "3.22.1"
+  }
+}

--- a/typescript-project-references/tsconfig.base.json
+++ b/typescript-project-references/tsconfig.base.json
@@ -1,0 +1,13 @@
+{
+    "compilerOptions": {
+      "sourceMap": true,
+      "strict": true,
+      "jsx": "react",
+      "composite": true,
+      "paths": {
+        "app2/*": ["./app2/src/*"]
+      }
+    },
+    "files": []
+  }
+  

--- a/yarn.lock
+++ b/yarn.lock
@@ -8204,7 +8204,7 @@ enhanced-resolve@^4.0.0, enhanced-resolve@^4.3.0, enhanced-resolve@^4.5.0:
     memory-fs "^0.5.0"
     tapable "^1.0.0"
 
-enhanced-resolve@^5.0.0, enhanced-resolve@^5.9.2, enhanced-resolve@^5.9.3:
+enhanced-resolve@^5.0.0, enhanced-resolve@^5.7.0, enhanced-resolve@^5.9.2, enhanced-resolve@^5.9.3:
   version "5.9.3"
   resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.9.3.tgz#44a342c012cbc473254af5cc6ae20ebd0aae5d88"
   integrity sha512-Bq9VSor+kjvW3f9/MiiR4eE3XYgOl7/rS8lnSxbRbF3kS0B2r+Y9w5krBWxZgDxASVZbdYrn5wT4j/Wb0J9qow==
@@ -18204,7 +18204,16 @@ ts-pnp@^1.1.6:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.2.0.tgz#a500ad084b0798f1c3071af391e65912c86bca92"
   integrity sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==
 
-tsconfig-paths@^3.14.1:
+tsconfig-paths-webpack-plugin@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-3.5.2.tgz#01aafff59130c04a8c4ebc96a3045c43c376449a"
+  integrity sha512-EhnfjHbzm5IYI9YPNVIxx1moxMI4bpHD2e0zTXeDNQcwjjRaGepP7IhTHJkyDBG0CAOoxRfe7jCG630Ou+C6Pw==
+  dependencies:
+    chalk "^4.1.0"
+    enhanced-resolve "^5.7.0"
+    tsconfig-paths "^3.9.0"
+
+tsconfig-paths@^3.14.1, tsconfig-paths@^3.9.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
   integrity sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==


### PR DESCRIPTION
This PR is a new example project for module federation using React with Typescript and Project References. It allows full typing between projects without manually creating type declarations.