### PR TITLE
refactor: CRA exemple without CRACO

### DIFF
--- a/cra/README.md
+++ b/cra/README.md
@@ -9,5 +9,5 @@ This example demos a basic host application loading remote component.
 
 Run `yarn start`. This will build and serve both `host` and `remote` on ports 3001 and 3002 respectively.
 
-- [localhost:3001](http://localhost:3001/) (HOST)
+- [localhost:3001](http://localhost:3000/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)

--- a/cra/host/craco.config.js
+++ b/cra/host/craco.config.js
@@ -1,9 +1,0 @@
-const cracoModuleFederation = require('craco-module-federation');
-
-module.exports = {
-  plugins: [
-    {
-      plugin: cracoModuleFederation,
-    },
-  ],
-};

--- a/cra/host/package.json
+++ b/cra/host/package.json
@@ -8,8 +8,8 @@
     "react-scripts": "5.0.1"
   },
   "scripts": {
-    "start": "craco start",
-    "build": "craco build",
+    "start": "node ./scripts/start.js",
+    "build": "node ./scripts/build.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -17,10 +17,6 @@
     "extends": [
       "react-app"
     ]
-  },
-  "devDependencies": {
-    "@craco/craco": "6.4.3",
-    "craco-module-federation": "1.1.0"
   },
   "browserslist": {
     "production": [

--- a/cra/host/scripts/build.js
+++ b/cra/host/scripts/build.js
@@ -1,0 +1,3 @@
+process.env.NODE_ENV = 'production';
+require('./overrides/webpack-config');
+require('react-scripts/scripts/build');

--- a/cra/host/scripts/overrides/webpack-config.js
+++ b/cra/host/scripts/overrides/webpack-config.js
@@ -1,0 +1,16 @@
+const { ModuleFederationPlugin } = require('webpack').container;
+
+const webpackConfigPath = 'react-scripts/config/webpack.config';
+const webpackConfig = require(webpackConfigPath);
+
+const override = (config) => {
+  config.plugins.push(new ModuleFederationPlugin(require('../../modulefederation.config.js')));
+
+  config.output.publicPath = 'auto';
+
+  return config;
+};
+
+require.cache[require.resolve(webpackConfigPath)].exports = (env) => override(webpackConfig(env));
+
+module.exports = require(webpackConfigPath);

--- a/cra/host/scripts/start.js
+++ b/cra/host/scripts/start.js
@@ -1,0 +1,3 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+require('./overrides/webpack-config');
+require('react-scripts/scripts/start');

--- a/cra/remote/craco.config.js
+++ b/cra/remote/craco.config.js
@@ -1,9 +1,0 @@
-const cracoModuleFederation = require('craco-module-federation');
-
-module.exports = {
-  plugins: [
-    {
-      plugin: cracoModuleFederation,
-    },
-  ],
-};

--- a/cra/remote/package.json
+++ b/cra/remote/package.json
@@ -8,8 +8,8 @@
     "react-scripts": "5.0.1"
   },
   "scripts": {
-    "start": "craco start",
-    "build": "craco build",
+    "start": "PORT=3002 node ./scripts/start.js",
+    "build": "node ./scripts/build.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
@@ -17,10 +17,6 @@
     "extends": [
       "react-app"
     ]
-  },
-  "devDependencies": {
-    "@craco/craco": "6.4.3",
-    "craco-module-federation": "1.1.0"
   },
   "browserslist": {
     "production": [

--- a/cra/remote/scripts/build.js
+++ b/cra/remote/scripts/build.js
@@ -1,0 +1,3 @@
+process.env.NODE_ENV = 'production';
+require('./overrides/webpack-config');
+require('react-scripts/scripts/build');

--- a/cra/remote/scripts/overrides/webpack-config.js
+++ b/cra/remote/scripts/overrides/webpack-config.js
@@ -1,0 +1,16 @@
+const { ModuleFederationPlugin } = require('webpack').container;
+
+const webpackConfigPath = 'react-scripts/config/webpack.config';
+const webpackConfig = require(webpackConfigPath);
+
+const override = (config) => {
+  config.plugins.push(new ModuleFederationPlugin(require('../../modulefederation.config.js')));
+
+  config.output.publicPath = 'auto';
+
+  return config;
+};
+
+require.cache[require.resolve(webpackConfigPath)].exports = (env) => override(webpackConfig(env));
+
+module.exports = require(webpackConfigPath);

--- a/cra/remote/scripts/start.js
+++ b/cra/remote/scripts/start.js
@@ -1,0 +1,3 @@
+process.env.NODE_ENV = process.env.NODE_ENV || 'development';
+require('./overrides/webpack-config');
+require('react-scripts/scripts/start');


### PR DESCRIPTION
CRACO don't support CRA 5 yet and [searching for maintainers](https://github.com/gsoft-inc/craco/issues/415).

However, [CRA still does not have a way of working with Module Federation](https://github.com/facebook/create-react-app/issues/9510).

This solution:
- Does not require any external dependency on the CRA
- Does not need to be ejected
- Small code implementation

Source:
https://github.com/luigidomingues/extend-cra-config

This PR resolve this issues:
- https://github.com/module-federation/module-federation-examples/issues/756
- https://github.com/module-federation/module-federation-examples/issues/755