### PR TITLE
[react-hmr] Fix TypeError: cli.isMultipleCompiler is not a function

### DIFF
--- a/react-hmr/host/package.json
+++ b/react-hmr/host/package.json
@@ -15,7 +15,7 @@
     "external-remotes-plugin": "1.0.0",
     "html-webpack-plugin": "5.5.0",
     "webpack": "5.72.1",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.8.1",
     "webpack-livereload-plugin": "3.0.2"
   },

--- a/react-hmr/libs/package.json
+++ b/react-hmr/libs/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "webpack": "5.72.1",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.8.1"
   }
 }

--- a/react-hmr/remote1/package.json
+++ b/react-hmr/remote1/package.json
@@ -16,7 +16,7 @@
     "html-webpack-plugin": "5.5.0",
     "react-refresh": "0.13.0",
     "webpack": "5.72.1",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.8.1"
   },
   "dependencies": {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5066,6 +5066,11 @@
   resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.1.1.tgz#9f53b1b7946a6efc2a749095a4f450e2932e8356"
   integrity sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==
 
+"@webpack-cli/configtest@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.2.0.tgz#7b20ce1c12533912c3b217ea68262365fa29a6f5"
+  integrity sha512-4FB8Tj6xyVkyqjj1OaTqCjXYULB9FMkqQ8yGrZjRDrYh0nOE+7Lhs45WioWQQMV+ceFlE368Ukhe6xdvJM9Egg==
+
 "@webpack-cli/info@^1.4.1":
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.4.1.tgz#2360ea1710cbbb97ff156a3f0f24556e0fc1ebea"
@@ -5073,10 +5078,22 @@
   dependencies:
     envinfo "^7.7.3"
 
+"@webpack-cli/info@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.5.0.tgz#6c78c13c5874852d6e2dd17f08a41f3fe4c261b1"
+  integrity sha512-e8tSXZpw2hPl2uMJY6fsMswaok5FdlGNRTktvFk2sD8RjH0hE2+XistawJx1vmKteh4NmGmNUrp+Tb2w+udPcQ==
+  dependencies:
+    envinfo "^7.7.3"
+
 "@webpack-cli/serve@^1.6.1":
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.6.1.tgz#0de2875ac31b46b6c5bb1ae0a7d7f0ba5678dffe"
   integrity sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==
+
+"@webpack-cli/serve@^1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.7.0.tgz#e1993689ac42d2b16e9194376cfb6753f6254db1"
+  integrity sha512-oxnCNGj88fL+xzV+dacXs44HcDwf1ovs3AuEzvP7mqXw7fQntqIhQ1BRmynh4qEKQSSSRSWVyXRjmTbZIX9V2Q==
 
 "@wessberg/ts-evaluator@0.0.27":
   version "0.0.27"
@@ -19911,6 +19928,24 @@ webpack-chain@6.5.1, webpack-chain@^6.5.1:
   dependencies:
     deepmerge "^1.5.2"
     javascript-stringify "^2.0.1"
+
+webpack-cli@4.10.0:
+  version "4.10.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.10.0.tgz#37c1d69c8d85214c5a65e589378f53aec64dab31"
+  integrity sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.0"
+    "@webpack-cli/configtest" "^1.2.0"
+    "@webpack-cli/info" "^1.5.0"
+    "@webpack-cli/serve" "^1.7.0"
+    colorette "^2.0.14"
+    commander "^7.0.0"
+    cross-spawn "^7.0.3"
+    fastest-levenshtein "^1.0.12"
+    import-local "^3.0.2"
+    interpret "^2.2.0"
+    rechoir "^0.7.0"
+    webpack-merge "^5.7.3"
 
 webpack-cli@4.9.2, webpack-cli@^4.0.0, webpack-cli@^4.9.2:
   version "4.9.2"


### PR DESCRIPTION
Fix the error "TypeError: cli.isMultipleCompiler is not a function" from webpack-cli that appears when executing `yarn start`.
Complete error log:
```
[0] [webpack-cli] TypeError: cli.isMultipleCompiler is not a function
[0]     at Command.<anonymous> (/Users/pcomanici/work/github/module-federation/module-federation-examples/react-hmr/node_modules/@webpack-cli/serve/lib/index.js:146:35)
[0]     at async Promise.all (index 1)
[0]     at async Command.<anonymous> (/Users/pcomanici/work/github/module-federation/module-federation-examples/react-hmr/node_modules/webpack-cli/lib/webpack-cli.js:1674:7)
error Command failed with exit code 2.
```

The fix consists in upgrading webpack-cli to v4.10.0