### PR TITLE
fix(routing): not found main.js & remoteEntry.js

### DIFF
--- a/shared-routing/dashboard/webpack.config.js
+++ b/shared-routing/dashboard/webpack.config.js
@@ -73,6 +73,7 @@ module.exports = {
     }),
     new HtmlWebpackPlugin({
       template: './public/index.html',
+      publicPath: '/',
     }),
   ],
 };

--- a/shared-routing/order/webpack.config.js
+++ b/shared-routing/order/webpack.config.js
@@ -70,6 +70,7 @@ module.exports = {
     }),
     new HtmlWebpackPlugin({
       template: './public/index.html',
+      publicPath: '/',
     }),
   ],
 };

--- a/shared-routing/profile/webpack.config.js
+++ b/shared-routing/profile/webpack.config.js
@@ -74,6 +74,7 @@ module.exports = {
     }),
     new HtmlWebpackPlugin({
       template: './public/index.html',
+      publicPath: '/',
     }),
   ],
 };

--- a/shared-routing/sales/webpack.config.js
+++ b/shared-routing/sales/webpack.config.js
@@ -68,6 +68,7 @@ module.exports = {
     }),
     new HtmlWebpackPlugin({
       template: './public/index.html',
+      publicPath: '/',
     }),
   ],
 };

--- a/shared-routing/shell/webpack.config.js
+++ b/shared-routing/shell/webpack.config.js
@@ -82,6 +82,7 @@ module.exports = {
     }),
     new HtmlWebpackPlugin({
       template: './public/index.html',
+      publicPath: '/',
     }),
   ],
 };


### PR DESCRIPTION
If landing on a "deep" route path like `/profile/foo/bar`, main.js and remoteEntry.js assets are not found.
The problem is that script tags src in the HTML are not absolute (`main.js` instead of `/main.js`).
 
This can be solved by either:

- change `publicPath` from `auto` to a "hard-coded" URL (ie. http://localhost:3001/).
- use `HashRouter`.

Is there any better solution?
Yes!
change `publicPath` in `html-webpack-plugin` to be `/`. 
This works just fine for me.

I know, it might be a problem with how `html-webpack-plugin` treat `auto`. 
Until we find out if it is, and create a PR, this is not a bad workaround :)