### PR TITLE
feat(): add error handling when remote is down

### DIFF
--- a/shared-routes2/app1/AddRuntimeRequiremetToPromiseExternal.js
+++ b/shared-routes2/app1/AddRuntimeRequiremetToPromiseExternal.js
@@ -1,0 +1,25 @@
+const pluginName = 'AddRuntimeRequiremetToPromiseExternalPlugin';
+
+class AddRuntimeRequiremetToPromiseExternalPlugin {
+    apply(compiler) {
+      compiler.hooks.compilation.tap(
+        pluginName,
+        (compilation) => {
+          const RuntimeGlobals = compiler.webpack.RuntimeGlobals;
+          if (compilation.outputOptions.trustedTypes) {
+            compilation.hooks.additionalModuleRuntimeRequirements.tap(
+              pluginName,
+              (module, set, context) => {
+                if (module.externalType === "promise") {
+                  set.add(RuntimeGlobals.loadScript);
+                  set.add(RuntimeGlobals.require);
+                }
+              }
+            );
+          }
+        }
+      );
+    }
+  }
+
+module.exports = AddRuntimeRequiremetToPromiseExternalPlugin;

--- a/shared-routes2/app1/src/placeholder.js
+++ b/shared-routes2/app1/src/placeholder.js
@@ -1,0 +1,4 @@
+// return a dummy module with an empty array
+module.exports = function routes() {
+    return [];
+};

--- a/shared-routes2/app1/webpack.config.js
+++ b/shared-routes2/app1/webpack.config.js
@@ -2,6 +2,8 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ModuleFederationPlugin = require('webpack').container.ModuleFederationPlugin;
 const path = require('path');
 const deps = require('./package.json').dependencies;
+const dummyModule = require('./src/placeholder');
+
 module.exports = {
   entry: './src/index',
   mode: 'development',
@@ -31,7 +33,35 @@ module.exports = {
       name: 'app1',
       filename: 'remoteEntry.js',
       remotes: {
-        app2: 'app2@http://localhost:3002/remoteEntry.js',
+        app2: `promise new Promise((resolve, reject) => {
+          const script = document.createElement('script')
+          script.src = "http://localhost:3002/remoteEntry.js"
+          script.onload = () => {
+            // the injected script has loaded and is available on window
+            // we can now resolve this Promise
+            const proxy = {
+              get: (request) => window.app2.get(request),
+              init: (arg) => {
+                try {
+                  return window.app2.init(arg)
+                } catch(e) {
+                  console.log('remote container already initialized')
+                }
+              }
+            }
+            resolve(proxy)
+          }
+          script.onerror = () => {
+            // script failed to load, return a placeholder module
+            console.log('app2 script failed to load, falling back to placeholder module');
+            let newProxy = {
+              get: (module, scope) => ${dummyModule},
+              init: () => {}
+            }
+            resolve(newProxy);
+          }
+          document.head.appendChild(script);
+        })`
       },
       exposes: {
         './Navigation': './src/Navigation',


### PR DESCRIPTION
When app2 is down the entire app crashes. Since the route definition is synchronous and happens before the app renders, we can't do a dynamic import like `const routes = await import('app2/routes')` in order to catch the error so it has to be caught before the module federation promise rejects.

