### PR TITLE
Fix 'cli.isMultipleCompiler is not a function' Error

### DIFF
--- a/vue2-in-vue3/vue2/package.json
+++ b/vue2-in-vue3/vue2/package.json
@@ -24,7 +24,7 @@
     "vue-loader": "15.9.8",
     "vue-template-compiler": "2.7.4",
     "webpack": "5.72.1",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.9.3"
   },
   "workspaces": {

--- a/vue2-in-vue3/vue3/package.json
+++ b/vue2-in-vue3/vue3/package.json
@@ -24,7 +24,7 @@
     "url-loader": "4.1.1",
     "vue-loader": "16.8.3",
     "webpack": "5.72.1",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.9.3"
   },
   "workspaces": {


### PR DESCRIPTION
Well, there are like 80 packages depending on the `"webpack-cli": "4.9.2"` out there, I decided to apply the [fix](https://github.com/webpack/webpack-cli/issues/3294) only to what I have actually tested.