### PR TITLE
fix: add splitChunks to vue3-cli-demo

### DIFF
--- a/vue3-cli-demo/app-exposes/vue.config.js
+++ b/vue3-cli-demo/app-exposes/vue.config.js
@@ -10,7 +10,24 @@ module.exports = defineConfig({
   publicPath: 'auto',
   configureWebpack: {
     optimization: {
-      splitChunks: false,
+      splitChunks:  {
+        cacheGroups: {
+          defaultVendors: {
+            name: 'chunk-vendors',
+            test: /[\\/]node_modules[\\/]/,
+            priority: -10,
+            chunks: 'async',
+            reuseExistingChunk: true,
+          },
+          common: {
+            name: 'chunk-common',
+            minChunks: 2,
+            priority: -20,
+            chunks: 'async',
+            reuseExistingChunk: true,
+          },
+        },
+      },
     },
     plugins: [
       new webpack.container.ModuleFederationPlugin({


### PR DESCRIPTION
add splitChunks to cover vue-cli default splitChunks config