### PR TITLE
 version-discrepancy/app1 lodash should be v4.10.0

### DIFF
--- a/version-discrepancy/app1/package.json
+++ b/version-discrepancy/app1/package.json
@@ -19,7 +19,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "lodash": "4.17.21",
+    "lodash": "4.10.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1"
   }


### PR DESCRIPTION
Dependabot being too aggressive.

Current [Renovatebot config](https://github.com/module-federation/module-federation-examples/blob/master/renovate.json#L24) already has the ignore