### PR TITLE
fix: Make react-host nextjs-remote work with nextjs-mf 5

### DIFF
--- a/react-nextjs/react-host-nextjs-remote/host/package.json
+++ b/react-nextjs/react-host-nextjs-remote/host/package.json
@@ -14,9 +14,9 @@
     "babel-loader": "^8.0.6",
     "concurrently": "^7.1.0",
     "html-webpack-plugin": "^5.3.1",
-    "serve": "^13.0.0",
+    "serve": "^14.0.1",
     "webpack": "^5.72.0",
-    "webpack-cli": "^4.9.2"
+    "webpack-cli": "^4.10.0"
   },
   "scripts": {
     "dev": "concurrently \"npm run start\" \"npm run serve\"",

--- a/react-nextjs/react-host-nextjs-remote/remote/next.config.js
+++ b/react-nextjs/react-host-nextjs-remote/remote/next.config.js
@@ -1,20 +1,31 @@
-const { withFederatedSidecar } = require('@module-federation/nextjs-mf');
+const NextFederationPlugin = require('@module-federation/nextjs-mf/lib/NextFederationPlugin')
 
-module.exports = withFederatedSidecar({
-  name: 'remote',
-  filename: 'static/chunks/remoteEntry.js',
-  exposes: {
-    './nextjs-remote-component': './components/nextjs-remote-component.js',
-    './nextjs-remote-page': './pages/index.js',
+module.exports = {
+  webpack(config, options) {
+    if (!options.isServer) {
+      config.plugins.push(
+        new NextFederationPlugin({
+          name: 'remote',
+          remotes: {},
+          filename: 'static/chunks/remoteEntry.js',
+          exposes: {
+            './nextjs-remote-component': './components/nextjs-remote-component.js',
+            './nextjs-remote-page': './pages/index.js',
+          },
+          shared: {
+            react: {
+              requiredVersion: false,
+              singleton: true
+            }
+          },
+          extraOptions: {
+            'skipSharingNextInternals': true
+          }
+        })
+      )
+    }
+    return config;
   },
-  shared: {
-    // react: {
-    //   // Notice shared are NOT eager here.
-    //   requiredVersion: false,
-    //   singleton: true,
-    // },
-  },
-})({
   // your original next.config.js export
   reactStrictMode: true,
-});
+};

--- a/react-nextjs/react-host-nextjs-remote/remote/package-lock.json
+++ b/react-nextjs/react-host-nextjs-remote/remote/package-lock.json
@@ -2909,6 +2909,21 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/@next/swc-freebsd-x64": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.2.tgz",
+      "integrity": "sha512-JUnXB+2xfxqsAvhFLPJpU1NeyDsvJrKoOjpV7g3Dxbno2Riu4tDKn3kKF886yleAuD/1qNTUCpqubTvbbT2VoA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
     }
   },
   "dependencies": {
@@ -4951,6 +4966,12 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "@next/swc-freebsd-x64": {
+      "version": "12.2.2",
+      "resolved": "https://registry.npmjs.org/@next/swc-freebsd-x64/-/swc-freebsd-x64-12.2.2.tgz",
+      "integrity": "sha512-JUnXB+2xfxqsAvhFLPJpU1NeyDsvJrKoOjpV7g3Dxbno2Riu4tDKn3kKF886yleAuD/1qNTUCpqubTvbbT2VoA==",
+      "optional": true
     }
   }
 }

--- a/react-nextjs/react-host-nextjs-remote/remote/package.json
+++ b/react-nextjs/react-host-nextjs-remote/remote/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@module-federation/nextjs-mf": "^3.5.0",
-    "next": "12.2.2",
+    "@module-federation/nextjs-mf": "5.2.1",
+    "next": "12.2.3",
     "react": "18.1.0",
     "react-dom": "18.1.0"
   },


### PR DESCRIPTION
Updates react-host/nextjs-remote example to work with version 5 of the plugin and the new NextFederationPlugin pattern.

Fixes https://github.com/module-federation/module-federation-examples/issues/2254