### PR TITLE
chore: align copyPlugin params to match API schema 

### DIFF
--- a/rust-wasm/packages/remote/webpack.config.js
+++ b/rust-wasm/packages/remote/webpack.config.js
@@ -3,7 +3,7 @@ const CopyPlugin = require('copy-webpack-plugin');
 const { ModuleFederationPlugin } = require('webpack').container;
 
 // @TODO: uncomment this if you want to dev on the Rust src code.
-// const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
+const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
 
 const dist = path.resolve(__dirname, 'dist');
 
@@ -26,16 +26,18 @@ module.exports = {
   },
   experiments: { asyncWebAssembly: true },
   plugins: [
-    new CopyPlugin([path.resolve(__dirname, 'public')]),
+    new CopyPlugin({patterns: [
+      {from: path.resolve(__dirname, "")}
+    ]}),
 
     // @TODO: uncomment this if you want to dev on the Rust src code.
     // Webpack will load the Rust code and compile it to Wasm using Wasm-Pack.
     // Wasm-pack will also generate all the JS bindings needed to interop with JS,
     // found in the `./pkg` directory.
 
-    // new WasmPackPlugin({
-    //   crateDirectory: __dirname,
-    // }),
+    new WasmPackPlugin({
+      crateDirectory: __dirname,
+    }),
 
     new ModuleFederationPlugin({
       name: 'GameOfLifeModule',


### PR DESCRIPTION
##### Description 

This pr fixes the **CopyWebpackPlugin** initialization 
by implementing an options object that matches the API schema.

https://webpack.js.org/plugins/copy-webpack-plugin/
```js

const CopyPlugin = require("copy-webpack-plugin");

module.exports = {
  plugins: [
    new CopyPlugin({
      patterns: [
        { from: "source", to: "dest" },
      ],
    }),
  ],
};
```


 