### PR TITLE
Add `node-fetch` dep in order to get SSR example working

### DIFF
--- a/server-side-rendering/shell/package.json
+++ b/server-side-rendering/shell/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "express": "^4.17.1",
+    "node-fetch": "2.6.7",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-helmet": "^6.0.0",

--- a/server-side-rendering/yarn.lock
+++ b/server-side-rendering/yarn.lock
@@ -2929,6 +2929,13 @@ node-environment-flags@^1.0.5:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
 
+node-fetch@2.6.7:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-forge@^1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
@@ -3753,6 +3760,11 @@ toidentifier@1.0.1:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.1.tgz#3be34321a88a820ed1bd80dfaa33e479fbb8dd35"
   integrity sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 tslib@^2.0.3:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
@@ -3857,6 +3869,11 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 webpack-cli@4.9.2, webpack-cli@^4.9.0:
   version "4.9.2"
@@ -3977,6 +3994,14 @@ websocket-extensions@>=0.1.1:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Background

I had an issue getting the `server-side-rendering` example working. It turns out I was missing an exact dependency of node-fetch in order to get it working.

## Errors

### Missing `node-fetch` dependency error

```
error Error: Cannot find module 'node-fetch'
```

### Using latest version of `node-fetch` error

The current version of `node-fetch` is an ESM module only and so does not interop with common-js very well. If you install the latest version of `node-fetch` you will get this error:

```
remoteUrl remote1@http://localhost:3001/server/remoteEntry.js
executing remote load http://localhost:3001/server/remoteEntry.js
error Error [ERR_REQUIRE_ESM]: Must use import to load ES Module: /Users/adam.recvlohe/Documents/dev/foss/module-federation-examples/server-side-rendering/node_modules/node-fetch/src/index.js
require() of ES modules is not supported.
require() of /Users/adam.recvlohe/Documents/dev/foss/module-federation-examples/server-side-rendering/node_modules/node-fetch/src/index.js from /Users/adam.recvlohe/Documents/dev/foss/module-federation-examples/server-side-rendering/shell/dist/server/main.js is an ES module file as it is a .js file whose nearest parent package.json contains "type": "module" which defines all .js files in that package scope as ES modules.
Instead rename index.js to end in .cjs, change the requiring code to use import(), or remove "type": "module" from /Users/adam.recvlohe/Documents/dev/foss/module-federation-examples/server-side-rendering/node_modules/node-fetch/package.json.
```

## Changes

- Install `node-fetch@2.6.7` in order to get example working correctly. Others might have had this dependency somewhere globally installed so it wasn't an issue until someone didn't have it
