### PR TITLE
Upgrade mf/node dependency to 0.1.0 for SSR example

### DIFF
--- a/server-side-rendering/remote1/package.json
+++ b/server-side-rendering/remote1/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-transform-runtime": "^7.15.8",
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
-    "@module-federation/node": "^0.0.1",
+    "@module-federation/node": "0.1.0",
     "babel-loader": "^8.2.2",
     "html-webpack-plugin": "^5.5.0",
     "webpack": "^5.57.1",

--- a/server-side-rendering/remote2/package.json
+++ b/server-side-rendering/remote2/package.json
@@ -18,7 +18,7 @@
     "@babel/plugin-transform-runtime": "^7.15.8",
     "@babel/preset-env": "^7.15.8",
     "@babel/preset-react": "^7.14.5",
-    "@module-federation/node": "^0.0.1",
+    "@module-federation/node": "0.1.0",
     "babel-loader": "^8.2.2",
     "webpack": "^5.57.1",
     "webpack-cli": "^4.9.0",

--- a/server-side-rendering/shell/package.json
+++ b/server-side-rendering/shell/package.json
@@ -32,7 +32,7 @@
     "@babel/polyfill": "^7.4.4",
     "@babel/preset-env": "7.18.2",
     "@babel/preset-react": "7.17.12",
-    "@module-federation/node": "^0.0.1",
+    "@module-federation/node": "0.1.0",
     "babel-loader": "8.2.5",
     "rimraf": "3.0.2",
     "webpack": "5.73.0",

--- a/server-side-rendering/yarn.lock
+++ b/server-side-rendering/yarn.lock
@@ -1072,10 +1072,10 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
-"@module-federation/node@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.npmjs.org/@module-federation/node/-/node-0.0.1.tgz#e37ef6515cae0ea37d2a86dabed18b91dff341aa"
-  integrity sha512-YQW2w5Knh9L95sOK6oRUDqlpf0U+IdYah3Rqmmeee2+Ny7XTPUdqOGwKgjKIGz3PnD4dLva2q94eUmuawBAtYg==
+"@module-federation/node@0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@module-federation/node/-/node-0.1.0.tgz#81680625e36af6560482e2bbb099f64d12ff9085"
+  integrity sha512-2cQlg+Jf8mTSNXXD6LVV0a/gHpB1fbg0GXBEumSrjTsaSsLhjFyoRRJafVHxI3hPw50fSrnjabKuQCDzu7RAeQ==
 
 "@nicolo-ribaudo/chokidar-2@2.1.8-no-fsevents.3":
   version "2.1.8-no-fsevents.3"


### PR DESCRIPTION
## Background

I am able to get the SSR version working with `0.1.0` but not `0.2.0` or higher. Pushing these changes so that it has the most up to date working version.

## Errors

The error I get for versions higher than `0.1.0` is

```
[Error: ENOENT: no such file or directory, open '/Users/adam.recvlohe/Documents/dev/artist-spikes/webpack-mf-ssr/shell/dist/server/242.js'
while loading "./Content" from 6822] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/adam.recvlohe/Documents/dev/artist-spikes/webpack-mf-ssr/shell/dist/server/242.js'
}
```

It seems the output is not what is expected somehow. This is okay for my purpose since it is working with what I need at the moment.