### PR TITLE
Docs: typo correction

### DIFF
--- a/react-nextjs/README.md
+++ b/react-nextjs/README.md
@@ -4,7 +4,7 @@
 
 This repo has some examples of module federation that may exist, and it's a WIP, so we will add examples along the way, for instance, react host with react remote and more.
 
-- Disclaimer for NextJS apps you need the lates version of `@module-federation/nextjs-mf` that is a paid module, you can red more [here](https://app.privjs.com/buy/packageDetail?pkg=@module-federation/nextjs-mf)
+- Disclaimer for NextJS apps you need the lates version of `@module-federation/nextjs-mf` that is a paid module, you can read more [here](https://app.privjs.com/buy/packageDetail?pkg=@module-federation/nextjs-mf)
 
 #### ⬇️ Host
 


### PR DESCRIPTION
Misspelt `read` as `red`. Fixed it.

Small correction.