### PR TITLE
Fix memory leaks and simplify examples

### DIFF
--- a/css-isolation/app2/src/appInjector.js
+++ b/css-isolation/app2/src/appInjector.js
@@ -10,4 +10,5 @@ export const inject = parentElementId => {
 
 export const cleanup = parentElementId => {
   deleteShadowContainer(parentElementId);
+  ReactDOM.unmountComponentAtNode(document.getElementById(parentElementId));
 };

--- a/different-react-versions-isolated/app1/package.json
+++ b/different-react-versions-isolated/app1/package.json
@@ -6,7 +6,6 @@
     "@babel/core": "7.16.7",
     "@babel/preset-react": "7.16.7",
     "babel-loader": "8.2.3",
-    "bundle-loader": "0.5.6",
     "html-webpack-plugin": "5.5.0",
     "serve": "12.0.1",
     "webpack": "5.61.0",

--- a/different-react-versions-isolated/app1/src/App.js
+++ b/different-react-versions-isolated/app1/src/App.js
@@ -4,7 +4,13 @@ const parentElementId = 'parent';
 
 const App = () => {
   useEffect(() => {
-    import('app2/injectApp').then(injector => injector.default(parentElementId));
+    let cleanup;
+    import('app2/appInjector').then(({ inject, unmount }) => {
+      inject(parentElementId);
+      cleanup = unmount;
+    });
+
+    return () => cleanup && cleanup(parentElementId);
   }, []);
 
   // App2 will be injected in the div with parentElementId

--- a/different-react-versions-isolated/app1/src/App.js
+++ b/different-react-versions-isolated/app1/src/App.js
@@ -1,16 +1,12 @@
 import React, { useEffect } from 'react';
+import { inject, cleanup } from 'app2/appInjector';
 
 const parentElementId = 'parent';
 
 const App = () => {
   useEffect(() => {
-    let cleanup;
-    import('app2/appInjector').then(({ inject, unmount }) => {
-      inject(parentElementId);
-      cleanup = unmount;
-    });
-
-    return () => cleanup && cleanup(parentElementId);
+    inject(parentElementId);
+    return () => cleanup(parentElementId);
   }, []);
 
   // App2 will be injected in the div with parentElementId

--- a/different-react-versions-isolated/app1/src/index.js
+++ b/different-react-versions-isolated/app1/src/index.js
@@ -1,2 +1,1 @@
-import bootstrap from './bootstrap';
-bootstrap(() => {});
+import('./bootstrap');

--- a/different-react-versions-isolated/app1/webpack.config.js
+++ b/different-react-versions-isolated/app1/webpack.config.js
@@ -17,13 +17,6 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /bootstrap\.js$/,
-        loader: 'bundle-loader',
-        options: {
-          lazy: true,
-        },
-      },
-      {
         test: /\.jsx?$/,
         loader: 'babel-loader',
         exclude: /node_modules/,

--- a/different-react-versions-isolated/app2/src/appInjector.js
+++ b/different-react-versions-isolated/app2/src/appInjector.js
@@ -1,0 +1,9 @@
+import App from './App';
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+export const inject = parentElementId =>
+  ReactDOM.render(<App />, document.getElementById(parentElementId));
+
+export const unmount = parentElementId =>
+  ReactDOM.unmountComponentAtNode(document.getElementById(parentElementId));

--- a/different-react-versions-isolated/app2/src/injectApp.js
+++ b/different-react-versions-isolated/app2/src/injectApp.js
@@ -1,8 +1,0 @@
-import App from './App';
-import React from 'react';
-import ReactDOM from 'react-dom';
-
-const injector = parentElementId =>
-  ReactDOM.render(<App />, document.getElementById(parentElementId));
-
-export default injector;

--- a/different-react-versions-isolated/app2/webpack.config.js
+++ b/different-react-versions-isolated/app2/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
       library: { type: 'var', name: 'app2' },
       filename: 'remoteEntry.js',
       exposes: {
-        './injectApp': './src/injectApp',
+        './appInjector': './src/appInjector',
       },
     }),
     new HtmlWebpackPlugin({

--- a/different-react-versions-isolated/yarn.lock
+++ b/different-react-versions-isolated/yarn.lock
@@ -1887,13 +1887,6 @@ builtins@^1.0.3:
   resolved "https://registry.yarnpkg.com/builtins/-/builtins-1.0.3.tgz#cb94faeb61c8696451db36534e1422f94f0aee88"
   integrity sha1-y5T662HIaWRR2zZTThQi+U8K7og=
 
-bundle-loader@0.5.6:
-  version "0.5.6"
-  resolved "https://registry.yarnpkg.com/bundle-loader/-/bundle-loader-0.5.6.tgz#6c9042e62f1c89941458805a3a479d10f34c71fd"
-  integrity sha512-SUgX+u/LJzlJiuoIghuubZ66eflehnjmqSfh/ib9DTe08sxRJ5F/MhHSjp7GfSJivSp8NWgez4PVNAUuMg7vSg==
-  dependencies:
-    loader-utils "^1.1.0"
-
 byline@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/byline/-/byline-5.0.0.tgz#741c5216468eadc457b03410118ad77de8c1ddb1"
@@ -4582,7 +4575,7 @@ loader-runner@^4.2.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
-loader-utils@^1.1.0, loader-utils@^1.4.0:
+loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==


### PR DESCRIPTION
- Simplified the example called `different-react-versions-isolated`
- Added `ReactDOM.unmountComponentAtNode()` to the cleanup in the remotes in `different-react-versions-isolated` and `css-isolation` examples. Without unmounting no cleanup functions in the remotes are ever called and memory starts to leak especially when the remotes are shown and hidden multiple times due to routing etc.