### PR TITLE
chore: simplify SSR example by removing thunk

### DIFF
--- a/server-side-render-only/hostServer/middleware.js
+++ b/server-side-render-only/hostServer/middleware.js
@@ -1,8 +1,0 @@
-export default async (express, app, done) => {
-  const renderThunk = require('./serverEntry').default;
-
-  const serverRender = renderThunk();
-  app.get('/*', serverRender);
-
-  done();
-};

--- a/server-side-render-only/hostServer/renderer.js
+++ b/server-side-render-only/hostServer/renderer.js
@@ -1,9 +1,0 @@
-import { renderToString } from 'react-dom/server';
-import React from 'react';
-import App from './App';
-
-export default async (req, res, next) => {
-  const html = renderToString(<App />);
-
-  res.send(html);
-};

--- a/server-side-render-only/hostServer/server.js
+++ b/server-side-render-only/hostServer/server.js
@@ -1,13 +1,21 @@
 import express from 'express';
 import React from 'react';
-import initMiddleware from './middleware';
+import { renderToString } from 'react-dom/server';
 
 const app = express();
 
-const done = () => {
-  app.listen(3000, () => {
-    console.log(`Server is listening on port: 3000`);
-  });
-};
+app.get('/*', async (req, res, next) => {
 
-initMiddleware(express, app, done);
+  // Don't statically import App.js, otherwise the Host app crashes on startup
+  // because there's no webpack module entry for "website2/SharedComponent" yet.
+  // The MF plugin will populate it during runtime, so dynamically import App.js to give it time
+
+  const App = (await import('./App')).default;
+  const html = renderToString(<App />);
+  res.send(html);
+});
+
+app.listen(3000, () => {
+  console.log(`Server is listening on port: 3000`);
+});
+

--- a/server-side-render-only/hostServer/serverEntry.js
+++ b/server-side-render-only/hostServer/serverEntry.js
@@ -1,4 +1,0 @@
-export default () => async (req, res, next) => {
-  const renderer = (await import('./renderer')).default;
-  return renderer(req, res, next);
-};


### PR DESCRIPTION
Hi @ScriptedAlchemy, thank you for these helpful examples!

I noticed that the Host app route controller here can be implemented with a simple dynamic import of `App.js` inside an Express async handler instead of needing a thunk middleware. If there's no particular advantage to the thunk, what do you think about simplifying this example?