### PR TITLE
e2e(scripts for run tests in back "all automated samples")

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,6 @@ buildServer
 /**/*/.prettierrc
 
 #Cypress folders
-cypress/videos/**
-cypress/downloads/**
-cypress/screenshots/**
+**/cypress/videos/**
+**/cypress/downloads/**
+**/cypress/screenshots/**

--- a/advanced-api/automatic-vendor-sharing/e2e/checkAutomaticVendorApps.cy.ts
+++ b/advanced-api/automatic-vendor-sharing/e2e/checkAutomaticVendorApps.cy.ts
@@ -42,17 +42,11 @@ appsData.forEach(
         const color = property.host === 3002 ? appsData[1].buttonColor : appsData[0].buttonColor;
 
         describe(`Check ${appName}`, () => {
-            // TODO cy.exec don't build the apps correctly cause lerna executes without exit code. Uncomment after fix this issue!
-            // before(() => {
-            //     basePage.buildTheSample(Constants.samplesPath.AdvancedApiAutomaticVendorSharing)
-            // })
-
-            // after(() => {
-            //     basePage.shutdownTheSample(Constants.samplesPath.AdvancedApiAutomaticVendorSharing)
-            // })
+            beforeEach(() => {
+                basePage.openLocalhost(host)
+            })
 
             it(`Check ${appName} built and running`, () => {
-                basePage.openLocalhost(host)
                 basePage.checkElementWithTextPresence({
                     selector: property.headerSelector,
                     text: property.headerText
@@ -64,7 +58,6 @@ appsData.forEach(
             })
 
             it(`Check buttons in ${appName} exist`, () => {
-                basePage.openLocalhost(host)
                 basePage.checkElementWithTextPresence({
                     selector: property.buttonSelector,
                     text: `${appName} ${Constants.commonText.button}`

--- a/advanced-api/automatic-vendor-sharing/package.json
+++ b/advanced-api/automatic-vendor-sharing/package.json
@@ -4,9 +4,11 @@
     "start": "lerna run --scope @automatic-vendor-sharing/* --parallel start",
     "build": "lerna run --scope @automatic-vendor-sharing/* build",
     "serve": "lerna run --scope @automatic-vendor-sharing/* --parallel serve",
-    "clean": "lerna run --scope @automatic-vendor-sharing/* --parallel clean"
+    "clean": "lerna run --scope @automatic-vendor-sharing/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/advanced-api/dynamic-remotes-runtime-environment-variables/package.json
+++ b/advanced-api/dynamic-remotes-runtime-environment-variables/package.json
@@ -8,11 +8,13 @@
     "clean": "lerna run --scope @dynamic-remotes-runtime-environment-variables/* --parallel clean",
     "docker:build": "lerna run --scope @dynamic-remotes-runtime-environment-variables/* --parallel docker:build",
     "docker:run": "lerna run --scope @dynamic-remotes-runtime-environment-variables/* --parallel docker:run",
-    "docker:rm": "lerna run --scope @dynamic-remotes-runtime-environment-variables/* --parallel docker:rm"
+    "docker:rm": "lerna run --scope @dynamic-remotes-runtime-environment-variables/* --parallel docker:rm",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3000/ && npx cypress run --config-file ../../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
     "copy-webpack-plugin": "11.0.0",
     "lerna": "4.0.0",
+    "wait-on": "7.0.1",
     "webpack-cli": "4.10.0"
   }
 }

--- a/advanced-api/dynamic-remotes-synchronous-imports/package.json
+++ b/advanced-api/dynamic-remotes-synchronous-imports/package.json
@@ -4,9 +4,11 @@
     "start": "lerna run --scope @dynamic-remotes-synchronous-imports/* --parallel start",
     "build": "lerna run --scope @dynamic-remotes-synchronous-imports/* build",
     "serve": "lerna run --scope @dynamic-remotes-synchronous-imports/* --parallel serve",
-    "clean": "lerna run --scope @dynamic-remotes-synchronous-imports/* --parallel clean"
+    "clean": "lerna run --scope @dynamic-remotes-synchronous-imports/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/advanced-api/dynamic-remotes/e2e/checkDynamicRemotesApps.cy.ts
+++ b/advanced-api/dynamic-remotes/e2e/checkDynamicRemotesApps.cy.ts
@@ -70,9 +70,11 @@ appsData.forEach(
         const widget: number = property.host === 3002 ? Number(appsData[1].widgetQuantity) : Number(appsData[2].widgetQuantity);
 
         describe(`Check ${appName}`, () => {
+            beforeEach(() => {
+                basePage.openLocalhost(host)
+            })
 
             it(`Check ${appName} built and running`, () => {
-                basePage.openLocalhost(host)
                 basePage.checkElementWithTextPresence({
                     selector: property.headerSelector,
                     text: property.headerText
@@ -116,7 +118,6 @@ appsData.forEach(
             })
 
             it(`Check functionality in ${appName}`, () => {
-                basePage.openLocalhost(host)
                 if (property.isButtonExist) {
                     Constants.elementsText.dynamicRemotesButtonsText.forEach(button => {
                         basePage.clickElementWithText({

--- a/advanced-api/dynamic-remotes/package.json
+++ b/advanced-api/dynamic-remotes/package.json
@@ -4,9 +4,11 @@
     "start": "lerna run --scope @dynamic-remotes/* --parallel start",
     "build": "lerna run --scope @dynamic-remotes/* build",
     "serve": "lerna run --scope @dynamic-remotes/* --parallel serve",
-    "clean": "lerna run --scope @dynamic-remotes/* --parallel clean"
+    "clean": "lerna run --scope @dynamic-remotes/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/angular11-microfrontends-ngrx/angular.json
+++ b/angular11-microfrontends-ngrx/angular.json
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
+    "analytics": false,
     "packageManager": "yarn"
   },
   "newProjectRoot": "projects",

--- a/angular11-microfrontends-ngrx/package.json
+++ b/angular11-microfrontends-ngrx/package.json
@@ -10,7 +10,8 @@
     "build:profile": "ng build mdmf-profile --prod",
     "test": "ng test mdmf-shared & ng test mdmf-profile & ng test mdmf-shell",
     "lint": "ng lint",
-    "e2e": "ng e2e mdmf-profile & ng e2e mdmf-shell"
+    "e2e": "ng e2e mdmf-profile & ng e2e mdmf-shell",
+    "e2e:ci": "yarn build:shared && yarn start:shell & wait-on http-get://localhost:4200/ && yarn start:profile & wait-on http-get://localhost:4201/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "private": true,
   "resolutions": {
@@ -25,8 +26,8 @@
     "@angular/platform-browser": "11.2.14",
     "@angular/platform-browser-dynamic": "11.2.14",
     "@angular/router": "11.2.14",
-    "@ngrx/store": "^11.0.0-beta.0",
     "@ngrx/router-store": "^11.0.0-beta.0",
+    "@ngrx/store": "^11.0.0-beta.0",
     "bootstrap": "^4.5.3",
     "rxjs": "~6.6.0",
     "tslib": "^2.0.0",
@@ -54,6 +55,7 @@
     "protractor": "7.0.0",
     "ts-node": "9.1.1",
     "tslint": "6.1.3",
-    "typescript": "4.3.5"
+    "typescript": "4.0.2",
+    "wait-on": "7.0.1"
   }
 }

--- a/angular11-microfrontends-ngxs/angular.json
+++ b/angular11-microfrontends-ngxs/angular.json
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
+    "analytics": false,
     "packageManager": "yarn"
   },
   "newProjectRoot": "projects",

--- a/angular11-microfrontends-ngxs/package.json
+++ b/angular11-microfrontends-ngxs/package.json
@@ -10,7 +10,8 @@
     "build:profile": "ng build mdmf-profile --prod",
     "test": "ng test mdmf-shared & ng test mdmf-profile & ng test mdmf-shell",
     "lint": "ng lint",
-    "e2e": "ng e2e mdmf-profile & ng e2e mdmf-shell"
+    "e2e": "ng e2e mdmf-profile & ng e2e mdmf-shell",
+    "e2e:ci": "yarn build:shared && yarn start:shell & wait-on http-get://localhost:4200/ && yarn start:profile & wait-on http-get://localhost:4201/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "private": true,
   "resolutions": {
@@ -54,6 +55,7 @@
     "protractor": "7.0.0",
     "ts-node": "9.1.1",
     "tslint": "6.1.3",
-    "typescript": "4.3.5"
+    "typescript": "4.0.2",
+    "wait-on": "7.0.1"
   }
 }

--- a/angular11-microfrontends-scully/angular.json
+++ b/angular11-microfrontends-scully/angular.json
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
+    "analytics": false,
     "packageManager": "yarn"
   },
   "newProjectRoot": "projects",

--- a/angular11-microfrontends-scully/package.json
+++ b/angular11-microfrontends-scully/package.json
@@ -16,7 +16,8 @@
     "scully:light": "scully",
     "scully:serve": "scully serve",
     "scully:route": "scully --scanRoutes",
-    "scully:debug": "scully --scanRoutes --stats --showGuessError --watch --logSeverity=normal"
+    "scully:debug": "scully --scanRoutes --stats --showGuessError --watch --logSeverity=normal",
+    "e2e:ci": "yarn build:shared && yarn start:shell & wait-on http-get://localhost:4200/ && yarn start:profile & wait-on http-get://localhost:4201/ && yarn start:product & wait-on http-get://localhost:4202/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "private": true,
   "resolutions": {
@@ -63,6 +64,7 @@
     "protractor": "7.0.0",
     "ts-node": "9.1.1",
     "tslint": "6.1.3",
-    "typescript": "4.3.5"
+    "typescript": "4.0.2",
+    "wait-on": "7.0.1"
   }
 }

--- a/angular12-microfrontends/angular.json
+++ b/angular12-microfrontends/angular.json
@@ -2,6 +2,7 @@
   "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "cli": {
+    "analytics": false,
     "packageManager": "yarn"
   },
   "newProjectRoot": "projects",

--- a/angular12-microfrontends/package.json
+++ b/angular12-microfrontends/package.json
@@ -9,7 +9,8 @@
     "build:profile": "ng build mdmf-profile --configuration production",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "e2e:ci": "ng serve mdmf-shell & wait-on http-get://localhost:4200/ && ng serve mdmf-profile & wait-on http-get://localhost:4201/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "private": true,
   "dependencies": {
@@ -46,6 +47,7 @@
     "ts-node": "9.1.1",
     "tslint": "6.1.3",
     "typescript": "4.3.5",
+    "wait-on": "^7.0.1",
     "webpack": "5.72.1"
   }
 }

--- a/angular15-microfrontends-lazy-components/package.json
+++ b/angular15-microfrontends-lazy-components/package.json
@@ -10,7 +10,8 @@
     "build:profile": "ng build mdmf-profile --prod",
     "test": "ng test mdmf-shared & ng test mdmf-profile & ng test mdmf-shell",
     "lint": "ng lint",
-    "e2e": "ng e2e mdmf-profile & ng e2e mdmf-shell"
+    "e2e": "ng e2e mdmf-profile & ng e2e mdmf-shell",
+    "e2e:ci": "yarn build:shared && yarn start:shell & wait-on http-get://localhost:4200/ && yarn start:profile & wait-on http-get://localhost:4201/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "private": true,
   "dependencies": {
@@ -49,6 +50,7 @@
     "protractor": "7.0.0",
     "ts-node": "9.1.1",
     "tslint": "6.1.3",
-    "typescript": "4.8.4"
+    "typescript": "4.8.4",
+    "wait-on": "7.0.1"
   }
 }

--- a/basic-host-remote/package.json
+++ b/basic-host-remote/package.json
@@ -10,9 +10,11 @@
     "start": "lerna run --parallel start",
     "build": "lerna run build",
     "serve": "lerna run --parallel serve",
-    "clean": "lerna run --parallel clean"
+    "clean": "lerna run --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/bi-directional/package.json
+++ b/bi-directional/package.json
@@ -4,12 +4,17 @@
     "start": "yarn build && yarn serve",
     "build": "concurrently \"cd app1; yarn build\" \"cd app2; yarn build\"",
     "serve": "concurrently \"cd app1; yarn serve\" \"cd app2; yarn serve\"",
-    "clean": "concurrently \"cd app1; yarn clean\" \"cd app2; yarn clean\""
+    "clean": "concurrently \"cd app1; yarn clean\" \"cd app2; yarn clean\"",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "workspaces": {
     "packages": [
       "./app1",
       "./app2"
     ]
+  },
+  "devDependencies": {
+    "concurrently": "7.6.0",
+    "wait-on": "7.0.1"
   }
 }

--- a/complete-react-case/package.json
+++ b/complete-react-case/package.json
@@ -12,7 +12,8 @@
     ]
   },
   "scripts": {
-    "start": "concurrently 'cd ./component-app && yarn start' 'cd ./lib-app && yarn start' 'cd ./main-app && yarn start'"
+    "start": "concurrently 'cd ./component-app && yarn start' 'cd ./lib-app && yarn start' 'cd ./main-app && yarn start'",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3002/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +23,7 @@
   },
   "homepage": "https://github.com/anderlaw/react-webpack-MF#readme",
   "devDependencies": {
-    "concurrently": "7.3.0"
+    "concurrently": "7.3.0",
+    "wait-on": "7.0.1"
   }
 }

--- a/cypress/common/base.ts
+++ b/cypress/common/base.ts
@@ -12,7 +12,7 @@ export class BaseMethods {
         cy.exec(command)
     }
 
-    public skipTestByCondition(condition : any): void {
+    public skipTestByCondition(condition: any): void {
         cy.skipWhen(condition)
     }
 
@@ -34,15 +34,15 @@ export class BaseMethods {
             .eq(index)
             .invoke('text')
             .then((baseText: string) => {
-                cy.origin(Cypress.env(`localhost${extraHost}`), {args: {baseText, selector, isEqual, clickSelector, wait}}, ({baseText, selector, isEqual, clickSelector, wait}) => {
+                cy.origin(Cypress.env(`localhost${extraHost}`), { args: { baseText, selector, isEqual, clickSelector, wait } }, ({ baseText, selector, isEqual, clickSelector, wait }) => {
                     cy.visit('/')
-                    if(clickSelector) {
+                    if (clickSelector) {
                         cy.get(clickSelector).click().wait(wait)
                     }
                     cy.get(selector)
                         .invoke('text')
                         .then((text: string) => {
-                            if(isEqual) {
+                            if (isEqual) {
                                 expect(text).to.be.eq(baseText)
 
                                 return;
@@ -55,15 +55,15 @@ export class BaseMethods {
     }
 
     public checkUrlText(url: string, isInclude: boolean = false): void {
-         cy.url().should(isInclude? 'include' : 'not.include', url);
+        cy.url().should(isInclude ? 'include' : 'not.include', url);
     }
 
     public checkElementExist({
-         selector,
-         isVisible = true,
-         notVisibleState = 'not.exist',
-         visibleState = 'be.visible',
-     }: {
+        selector,
+        isVisible = true,
+        notVisibleState = 'not.exist',
+        visibleState = 'be.visible',
+    }: {
         selector: string,
         isVisible?: boolean,
         notVisibleState?: string,
@@ -84,19 +84,19 @@ export class BaseMethods {
         selector: string,
         index?: number,
         isForce?: boolean,
-        parentSelector? : string,
+        parentSelector?: string,
         isMultiple?: boolean,
         wait?: number
     }): Cypress.Chainable<JQuery<HTMLElement>> {
         if (index) {
-            return cy.get(selector).eq(index).wait(wait).click({force: isForce, multiple: isMultiple})
+            return cy.get(selector).eq(index).wait(wait).click({ force: isForce, multiple: isMultiple })
         }
 
         if (parentSelector) {
-            return cy.get(parentSelector).find(selector).wait(wait).click({force: isForce, multiple: isMultiple})
+            return cy.get(parentSelector).find(selector).wait(wait).click({ force: isForce, multiple: isMultiple })
         }
 
-        return cy.get(selector).wait(wait).click({force: isForce, multiple: isMultiple})
+        return cy.get(selector).wait(wait).click({ force: isForce, multiple: isMultiple })
     }
 
     public clickElementWithText({
@@ -112,7 +112,7 @@ export class BaseMethods {
     }): void {
         cy.get(selector)
             .contains(text)
-            .click({force: isForce})
+            .click({ force: isForce })
             .wait(wait)
     }
 
@@ -134,13 +134,13 @@ export class BaseMethods {
                 .find(childSelector)
                 .eq(index)
                 .contains(text)
-                .click({force: isForce})
+                .click({ force: isForce })
         }
 
         return cy.get(selector)
             .find(childSelector)
             .contains(text)
-            .click({force: isForce})
+            .click({ force: isForce })
     }
 
     public checkElementWithTextPresence({
@@ -160,7 +160,7 @@ export class BaseMethods {
         notVisibleState?: string,
         parentSelector?: string,
         isMultiple?: boolean,
-        wait? : number
+        wait?: number
         index?: number
     }): Cypress.Chainable<JQuery<HTMLElement>> {
         if (parentSelector) {
@@ -170,7 +170,7 @@ export class BaseMethods {
                 .should(isVisible ? visibilityState : notVisibleState);
         }
 
-        if(index) {
+        if (index) {
             return cy
                 .get(selector)
                 .eq(index)
@@ -178,7 +178,7 @@ export class BaseMethods {
                 .should(isVisible ? visibilityState : notVisibleState);
         }
 
-        if(isMultiple) {
+        if (isMultiple) {
             return cy.get(selector)
                 .each((element: JQuery<HTMLElement>) => {
                     expect(element.text()).to.include(text)
@@ -229,10 +229,10 @@ export class BaseMethods {
         childSelector: string,
         isVisible: boolean = true,
         visibilityState: string = 'be.visible',
-        text? : string,
+        text?: string,
         notVisibleState: string = 'not.exist',
-): Cypress.Chainable<JQuery<HTMLElement>> {
-        if(text) {
+    ): Cypress.Chainable<JQuery<HTMLElement>> {
+        if (text) {
             return cy
                 .get(selector).contains(text).parent(selector)
                 .find(childSelector)
@@ -320,7 +320,7 @@ export class BaseMethods {
         parentSelector?: string
     }
     ): void {
-        if(parentSelector) {
+        if (parentSelector) {
             cy.get(parentSelector)
                 .find(selector)
                 .invoke(attr, prop)
@@ -432,7 +432,7 @@ export class BaseMethods {
             return;
         }
 
-        if(text) {
+        if (text) {
             cy.get(selector).should('contain.text', text).and(state, quantity)
 
             return;
@@ -473,7 +473,7 @@ export class BaseMethods {
             return;
         }
 
-        if(text) {
+        if (text) {
             cy.get(selector).contains(text).should(state)
 
             return;
@@ -544,7 +544,7 @@ export class BaseMethods {
         existedText: string,
         notExistedText: string
     ): Cypress.Chainable<JQuery<HTMLElement>> {
-        return cy.origin(Cypress.env(`localhost${host}`), {args: {element, existedText, notExistedText}}, ({element, existedText, notExistedText}) => {
+        return cy.origin(Cypress.env(`localhost${host}`), { args: { element, existedText, notExistedText } }, ({ element, existedText, notExistedText }) => {
             cy.visit('/')
             // do not get it as checkElementWithTextPresence() due to inability of origin to get outside methods
             cy.get(element).contains(existedText).should('be.visible')
@@ -559,7 +559,7 @@ export class BaseMethods {
     public sendInputText({
         selector,
         text
-    }: {    
+    }: {
         selector: string,
         text: string,
     }) {
@@ -610,7 +610,7 @@ export class BaseMethods {
     }
 
     private _checkInputValue(text: string, value: string, isLengthChecked: boolean = false): void {
-        if(isLengthChecked) {
+        if (isLengthChecked) {
             expect(text.length).to.be.eq(value.length)
 
             return;

--- a/different-react-versions-isolated/package.json
+++ b/different-react-versions-isolated/package.json
@@ -10,9 +10,11 @@
     "start": "lerna run --parallel start",
     "build": "lerna run build",
     "serve": "lerna run --parallel serve",
-    "clean": "lerna run --parallel clean"
+    "clean": "lerna run --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/different-react-versions/package.json
+++ b/different-react-versions/package.json
@@ -10,9 +10,11 @@
     "start": "lerna run --parallel start",
     "build": "lerna run build",
     "serve": "lerna run --parallel serve",
-    "clean": "lerna run --parallel clean"
+    "clean": "lerna run --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/dynamic-system-host/package.json
+++ b/dynamic-system-host/package.json
@@ -4,10 +4,12 @@
     "start": "lerna run --scope @dynamic-system-host/* --parallel start",
     "build": "lerna run --scope @dynamic-system-host/* build",
     "serve": "lerna run --scope @dynamic-system-host/* --parallel serve",
-    "clean": "lerna run --scope @dynamic-system-host/* --parallel clean"
+    "clean": "lerna run --scope @dynamic-system-host/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   },
   "workspaces": {
     "packages": [

--- a/i18next-nextjs-react/package.json
+++ b/i18next-nextjs-react/package.json
@@ -4,8 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "concurrently \"cd next-host; npm run dev\" \"cd react-host; npm run start:live\" \"cd react-remote; npm run start:live\" \"cd i18next-shared-lib; npm run dev\"",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "concurrently \"cd next-host; npm run dev\" \"cd react-host; npm run start:live\" \"cd react-remote; npm run start:live\" \"cd i18next-shared-lib; npm run dev\""
   },
   "private": true,
   "workspaces": [

--- a/native-federation-react/package.json
+++ b/native-federation-react/package.json
@@ -9,7 +9,8 @@
     "build": "npm run build:remote && npm run build:host",
     "start:remote": "serve dist/remote -l 3001 --cors",
     "start:host": "serve dist/host -l 3000",
-    "start": "concurrently \"npm run start:remote\" \"npm run start:host\""
+    "start": "concurrently \"npm run start:remote\" \"npm run start:host\"",
+    "e2e:ci": "npm run build && npm run start & wait-on http-get://localhost:3000/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/runAll.cy.ts\" --browser=chrome"
   },
   "keywords": [],
   "author": "",
@@ -23,7 +24,8 @@
     "esbuild": "^0.15.5",
     "esm-node-services": "^0.7.4",
     "json5": "^2.2.1",
-    "serve": "^14.0.1"
+    "serve": "^14.0.1",
+    "wait-on": "7.0.1"
   },
   "dependencies": {
     "date-fns": "^2.29.2",

--- a/nested/e2e/checkApp3.cy.ts
+++ b/nested/e2e/checkApp3.cy.ts
@@ -26,10 +26,11 @@ describe("Check App 3", () => {
     })
 
     it('Check button color', () => {
-        basePage.checkElementWithTextHaveCssProperty(
-            baseSelectors.button,
-            Constants.elementsText.nestedApp3Button,
-            CssAttr.background,
-            Constants.color.aquamarine)
+        basePage.checkElementWithTextHaveProperty({
+            selector: baseSelectors.button,
+            text: Constants.elementsText.nestedApp3Button,
+            prop: CssAttr.background,
+            value: Constants.color.aquamarine
+        })
     })
 })

--- a/nested/package.json
+++ b/nested/package.json
@@ -11,9 +11,11 @@
     "start": "lerna run --parallel start",
     "build": "lerna run build",
     "serve": "lerna run --parallel serve",
-    "clean": "lerna run --parallel clean"
+    "clean": "lerna run --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/runAll.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/react-nextjs/react-host-remote/package.json
+++ b/react-nextjs/react-host-remote/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "start": "concurrently \"cd host; npm run dev\" \"cd remote; npm run dev\""
+    "start": "concurrently \"cd host; npm run dev\" \"cd remote; npm run dev\"",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:8080/ && npx cypress run --config-file ../../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "private": true,
   "workspaces": [
@@ -14,6 +15,7 @@
   "author": "Omher",
   "license": "ISC",
   "devDependencies": {
-    "concurrently": "7.3.0"
+    "concurrently": "7.3.0",
+    "wait-on": "^7.0.1"
   }
 }

--- a/redux-reducer-injection/package.json
+++ b/redux-reducer-injection/package.json
@@ -4,10 +4,12 @@
     "start": "concurrently \"lerna run --scope @redux-reducer-injection/* --parallel start\" \"yarn serve\"",
     "build": "lerna run --scope @redux-reducer-injection/* build",
     "serve": "lerna run --scope @redux-reducer-injection/* --parallel serve",
-    "clean": "lerna run --scope @redux-reducer-injection/* --parallel clean"
+    "clean": "lerna run --scope @redux-reducer-injection/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
+    "concurrently": "7.3.0",
     "lerna": "3.22.1",
-    "concurrently": "7.3.0"
+    "wait-on": "^7.0.1"
   }
 }

--- a/self-healing/package.json
+++ b/self-healing/package.json
@@ -1,12 +1,14 @@
 {
   "private": true,
   "scripts": {
-    "start": "lerna run --scope @self-healing/* --parallel start",
-    "build": "lerna run --scope @self-healing/* build",
-    "serve": "lerna run --scope @self-healing/* --parallel serve",
-    "clean": "lerna run --scope @self-healing/* --parallel clean"
+    "start": "lerna run --scope=self-healing_app* --parallel start",
+    "build": "lerna run --scope=self-healing_app* build",
+    "serve": "lerna run --scope=self-healing_app* --parallel serve",
+    "clean": "lerna run --scope=self-healing_app* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/server-side-render-only/package.json
+++ b/server-side-render-only/package.json
@@ -6,7 +6,8 @@
     "buildHost": "webpack --config=hostServer/webpack.config.js -w",
     "startHost": "nodemon hostServer/public/server/server.js",
     "buildRemote": "webpack --config=remoteServer/webpack.config.js -w",
-    "startRemote": "nodemon remoteServer/public/server/server.js"
+    "startRemote": "nodemon remoteServer/public/server/server.js",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3000/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "license": "MIT",
   "author": {
@@ -19,8 +20,9 @@
     "@babel/preset-react": "7.18.6",
     "babel-loader": "8.2.5",
     "concurrently": "7.3.0",
-    "nodemon": "2.0.18",
     "lerna": "3.22.1",
+    "nodemon": "2.0.18",
+    "wait-on": "7.0.1",
     "webpack": "5.72.1",
     "webpack-cli": "4.10.0"
   },

--- a/shared-context/package.json
+++ b/shared-context/package.json
@@ -4,10 +4,12 @@
     "start": "lerna run --scope @shared-context/* --parallel start",
     "build": "lerna run --scope @shared-context/* build",
     "serve": "lerna run --scope @shared-context/* --parallel serve",
-    "clean": "lerna run --scope @shared-context/* --parallel clean"
+    "clean": "lerna run --scope @shared-context/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
     "lerna": "3.22.1",
+    "wait-on": "7.0.1",
     "webpack-cli": "^5.0.1"
   }
 }

--- a/shared-store-cross-framework/package.json
+++ b/shared-store-cross-framework/package.json
@@ -12,9 +12,11 @@
     "start": "lerna run --parallel start",
     "build": "lerna run build",
     "serve": "lerna run --parallel serve",
-    "clean": "lerna run --parallel clean"
+    "clean": "lerna run --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/runAll.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/typescript-monorepo/package.json
+++ b/typescript-monorepo/package.json
@@ -4,11 +4,15 @@
     "start": "lerna run --scope @typescript-monorepo/* --parallel start",
     "build": "lerna run --scope @typescript-monorepo/* build",
     "serve": "lerna run --scope @typescript-monorepo/* --parallel serve",
-    "clean": "lerna run --scope @typescript-monorepo/* --parallel clean"
+    "clean": "lerna run --scope @typescript-monorepo/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/runAll.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   },
-  "workspaces": ["app1/*", "app2/*"]
-
+  "workspaces": [
+    "app1/*",
+    "app2/*"
+  ]
 }

--- a/typescript-project-references/package.json
+++ b/typescript-project-references/package.json
@@ -4,9 +4,11 @@
     "start": "lerna run --scope @typescript-project-references/* --parallel start",
     "build": "lerna run --scope @typescript-project-references/* build",
     "serve": "lerna run --scope @typescript-project-references/* --parallel serve",
-    "clean": "lerna run --scope @typescript-project-references/* --parallel clean"
+    "clean": "lerna run --scope @typescript-project-references/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/version-discrepancy/package.json
+++ b/version-discrepancy/package.json
@@ -4,9 +4,11 @@
     "start": "lerna run --scope @version-discrepancy/* --parallel start",
     "build": "lerna run --scope @version-discrepancy/* build",
     "serve": "lerna run --scope @version-discrepancy/* --parallel serve",
-    "clean": "lerna run --scope @version-discrepancy/* --parallel clean"
+    "clean": "lerna run --scope @version-discrepancy/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/vue2-in-vue3/package.json
+++ b/vue2-in-vue3/package.json
@@ -4,9 +4,11 @@
     "start": "lerna run --scope @vue2-in-vue3/* --parallel start",
     "build": "lerna run --scope @vue2-in-vue3/* build",
     "serve": "lerna run --scope @vue2-in-vue3/* --parallel serve",
-    "clean": "lerna run --scope @vue2-in-vue3/* --parallel clean"
+    "clean": "lerna run --scope @vue2-in-vue3/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3002/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/*.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "7.0.1"
   }
 }

--- a/vue3-demo-federation-with-vite/package.json
+++ b/vue3-demo-federation-with-vite/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "scripts": {
     "build": "pnpm --parallel --filter \"./**\" build",
-    "serve": "pnpm --parallel --filter \"./**\"  serve"
+    "serve": "pnpm --parallel --filter \"./**\"  serve",
+    "e2e:ci": "pnpm build && pnpm serve & wait-on http-get://localhost:5000/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/runAll.cy.ts\" --browser=chrome"
+  },
+  "devDependencies": {
+    "wait-on": "7.0.1"
   }
 }

--- a/vue3-demo-federation-with-vite/pnpm-lock.yaml
+++ b/vue3-demo-federation-with-vite/pnpm-lock.yaml
@@ -3,7 +3,10 @@ lockfileVersion: 5.4
 importers:
 
   .:
-    specifiers: {}
+    specifiers:
+      wait-on: 7.0.1
+    devDependencies:
+      wait-on: 7.0.1
 
   vite-side:
     specifiers:
@@ -267,6 +270,16 @@ packages:
     dev: true
     optional: true
 
+  /@hapi/hoek/9.3.0:
+    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
+    dev: true
+
+  /@hapi/topo/5.1.0:
+    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
+    dependencies:
+      '@hapi/hoek': 9.3.0
+    dev: true
+
   /@jridgewell/gen-mapping/0.1.1:
     resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
@@ -330,6 +343,20 @@ packages:
     dependencies:
       estree-walker: 1.0.1
       magic-string: 0.25.9
+    dev: true
+
+  /@sideway/address/4.1.4:
+    resolution: {integrity: sha512-7vwq+rOHVWjyXxVlR76Agnvhy8I9rpzjosTESvmhNeXOXdZZB15Fl+TI9x1SiHZH5Jv2wTGduSxFDIaq0m3DUw==}
+    dependencies:
+      '@hapi/hoek': 9.3.0
+    dev: true
+
+  /@sideway/formula/3.0.1:
+    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
+    dev: true
+
+  /@sideway/pinpoint/2.0.0:
+    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
     dev: true
 
   /@types/eslint-scope/3.7.4:
@@ -885,6 +912,19 @@ packages:
     dependencies:
       lodash: 4.17.21
 
+  /asynckit/0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+    dev: true
+
+  /axios/0.27.2:
+    resolution: {integrity: sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==}
+    dependencies:
+      follow-redirects: 1.15.1
+      form-data: 4.0.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
+
   /babel-loader/8.2.5_xc6oct4hcywdrbo4ned6ytbybm:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
@@ -1123,6 +1163,13 @@ packages:
 
   /colorette/2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
+
+  /combined-stream/1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
+    dependencies:
+      delayed-stream: 1.0.0
+    dev: true
 
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1488,6 +1535,11 @@ packages:
       p-map: 4.0.0
       rimraf: 3.0.2
       slash: 3.0.0
+
+  /delayed-stream/1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
+    dev: true
 
   /depd/1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -2014,6 +2066,15 @@ packages:
       debug:
         optional: true
 
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: true
+
   /forwarded/0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
     engines: {node: '>= 0.6'}
@@ -2434,6 +2495,16 @@ packages:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
+  /joi/17.7.0:
+    resolution: {integrity: sha512-1/ugc8djfn93rTE3WRKdCzGGt/EtiYKxITMO4Wiv6q5JL1gl9ePt4kBsl1S499nbosspfctIQTpYIhSmHA3WAg==}
+    dependencies:
+      '@hapi/hoek': 9.3.0
+      '@hapi/topo': 5.1.0
+      '@sideway/address': 4.1.4
+      '@sideway/formula': 3.0.1
+      '@sideway/pinpoint': 2.0.0
+    dev: true
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: false
@@ -2611,14 +2682,14 @@ packages:
     dependencies:
       brace-expansion: 1.1.11
 
-  /minimist/1.2.6:
-    resolution: {integrity: sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==}
+  /minimist/1.2.7:
+    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
 
   /mkdirp/0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
     dependencies:
-      minimist: 1.2.6
+      minimist: 1.2.7
 
   /ms/2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -2984,7 +3055,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
-      minimist: 1.2.6
+      minimist: 1.2.7
       strip-json-comments: 2.0.1
     dev: false
 
@@ -3107,6 +3178,12 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+
+  /rxjs/7.8.0:
+    resolution: {integrity: sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==}
+    dependencies:
+      tslib: 2.4.0
+    dev: true
 
   /safe-buffer/5.1.2:
     resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
@@ -3634,6 +3711,20 @@ packages:
       '@vue/devtools-api': 6.2.1
       vue: 3.2.37
     dev: false
+
+  /wait-on/7.0.1:
+    resolution: {integrity: sha512-9AnJE9qTjRQOlTZIldAaf/da2eW0eSRSgcqq85mXQja/DW3MriHxkpODDSUEg+Gri/rKEcXUZHe+cevvYItaog==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+    dependencies:
+      axios: 0.27.2
+      joi: 17.7.0
+      lodash: 4.17.21
+      minimist: 1.2.7
+      rxjs: 7.8.0
+    transitivePeerDependencies:
+      - debug
+    dev: true
 
   /watchpack/2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}

--- a/vue3-demo/package.json
+++ b/vue3-demo/package.json
@@ -4,9 +4,11 @@
     "start": "lerna run --scope @vue3-demo/* --parallel start",
     "build": "lerna run --scope @vue3-demo/* build",
     "serve": "lerna run --scope @vue3-demo/* --parallel serve",
-    "clean": "lerna run --scope @vue3-demo/* --parallel clean"
+    "clean": "lerna run --scope @vue3-demo/* --parallel clean",
+    "e2e:ci": "yarn start & wait-on http-get://localhost:3001/ && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/runAll.cy.ts\" --browser=chrome"
   },
   "devDependencies": {
-    "lerna": "3.22.1"
+    "lerna": "3.22.1",
+    "wait-on": "^7.0.1"
   }
 }


### PR DESCRIPTION
Added scripts to samples package.json for build samples and run tests in the background to use it in CI pipeline in the future

Script example

```
"e2e:ci": "{build/run script} & wait-on {localhost} && npx cypress run --config-file ../cypress/config/cypress.config.ts --config '{\"supportFile\": \"../cypress/support/e2e.ts\"}' --spec \"./e2e/tests/*.cy.ts\" --browser=chrome"
```