### PR TITLE
chore(ng14-react): resolve @types/react in ng host app; add style-loader to react MFE

### DIFF
--- a/angular14-react/angular-profile/package.json
+++ b/angular14-react/angular-profile/package.json
@@ -10,7 +10,8 @@
   },
   "private": true,
   "resolutions": {
-    "webpack": "^5.74.0"
+    "webpack": "^5.74.0",
+    "@types/react": "^18.2.0"
   },
   "dependencies": {
     "@angular-builders/custom-webpack": "^14.0.1",

--- a/angular14-react/react-user-list/package.json
+++ b/angular14-react/react-user-list/package.json
@@ -10,6 +10,7 @@
     "css-loader": "^6.7.1",
     "file-loader": "6.2.0",
     "serve": "13.0.4",
+    "style-loader": "^3.3.1",
     "url-loader": "4.1.1",
     "webpack": "5.74.0",
     "webpack-cli": "4.10.0",

--- a/angular14-react/react-user-list/yarn.lock
+++ b/angular14-react/react-user-list/yarn.lock
@@ -3711,6 +3711,11 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+style-loader@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-3.3.1.tgz#057dfa6b3d4d7c7064462830f9113ed417d38575"
+  integrity sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==
+
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"


### PR DESCRIPTION
**Issue №1**:

There is a conflict when Yarn tries to resolve the `@types/react` dependency. This happens because yarn resolves both versions - from `package.json` directly and from `@types/react-dom` package. To avoid this we need to set a specific package version in `resolutions`.

<img width="1309" alt="Screenshot 2022-12-30 at 13 43 07" src="https://user-images.githubusercontent.com/6005171/210071429-13423309-5555-4c17-a000-3344b99ed946.png">

**Issue №2**:

We use `style-loader` in react MFE application but this dependency is missing in `package.json`

<img width="1320" alt="Screenshot 2022-12-30 at 13 39 54" src="https://user-images.githubusercontent.com/6005171/210071918-7c2cd114-711c-47bb-8bf6-315dedd2c12b.png">
