### PR TITLE
e2e(vite-vue-microfrontends) Added checks for the sample

### DIFF
--- a/cypress/common/base.ts
+++ b/cypress/common/base.ts
@@ -312,10 +312,18 @@ export class BaseMethods {
         visibilityState: string = 'be.visible',
         text?: string,
         notVisibleState: string = 'not.exist',
+        parentElement: boolean = true
 ): Cypress.Chainable<JQuery<HTMLElement>> {
-        if(text) {
+        if(text && parentElement) {
             return cy
                 .get(selector).contains(text).parent(selector)
+                .find(childSelector)
+                .should(isVisible ? visibilityState : notVisibleState);
+        }
+
+        if(text && !parentElement) {
+            return cy
+                .get(selector).contains(text)
                 .find(childSelector)
                 .should(isVisible ? visibilityState : notVisibleState);
         }

--- a/vite-vue-microfrontends/README.md
+++ b/vite-vue-microfrontends/README.md
@@ -8,7 +8,7 @@ From this directory execute:
 - npm run preview:remote
 - npm run preview:host (in a different terminal)
 
-Open your browser at http://localhost:5173/ to see the amazing result
+Open your browser at http://localhost:4173/ to see the amazing result
 
 ![screenshot](docs/screenshot.png)
 

--- a/vite-vue-microfrontends/e2e/tests/commonChecks.cy.ts
+++ b/vite-vue-microfrontends/e2e/tests/commonChecks.cy.ts
@@ -1,0 +1,50 @@
+import {BaseMethods} from "../../../cypress/common/base";
+import {selectors} from "../../../cypress/common/selectors";
+import {Constants} from "../../../cypress/fixtures/constants";
+
+const basePage: BaseMethods = new BaseMethods()
+
+describe('It checks names and symbols inside cards',  () => {
+    const appsData = [
+        {
+            cardName: Constants.commonText.viteReactMicroFrontendsCardsNames.hostCard,
+            symbolName: Constants.commonText.viteReactMicroFrontendsCardsSymbolsNames.starSymbol,
+            symbol: selectors.viteReactMicroFrontendsCardsSymbols.starSymbol,
+            status: Constants.elementsText.viteReactMicroFrontendsCardsMessages.hostCard
+        },
+        {
+            cardName:  Constants.commonText.viteReactMicroFrontendsCardsNames.remoteCard,
+            symbolName: Constants.commonText.viteReactMicroFrontendsCardsSymbolsNames.cloudSymbol,
+            symbol: selectors.viteReactMicroFrontendsCardsSymbols.cloudSymbol,
+            status: Constants.elementsText.viteReactMicroFrontendsCardsMessages.remoteCard
+        }
+    ]
+
+    appsData.forEach((property: { cardName: string, symbolName: string, symbol: string, status: string }) => {
+        it(`Checks ${property.symbolName} symbol visibility for ${property.cardName} card`, () => {
+            basePage.openLocalhost(4173)
+            basePage.checkElementQuantity({
+                selector: selectors.commonCardSelector,
+                quantity: 2,
+                waitUntil: true
+            })
+            basePage.checkChildElementVisibility(selectors.commonCardSelector,
+                property.symbol, true , 'be.visible',
+                property.status, 'not.exist', property.symbolName === appsData[0].symbolName)
+        });
+
+        it(`Checks ${property.cardName} card includes status`, () => {
+            basePage.openLocalhost(4173)
+            basePage.checkElementQuantity({
+                selector: selectors.commonCardSelector,
+                quantity: 2,
+                waitUntil: true
+            })
+            basePage.checkElementWithTextPresence({
+                selector: selectors.commonCardSelector,
+                text: property.status,
+                visibilityState: 'be.visible'
+            })
+        });
+    });
+});

--- a/vite-vue-microfrontends/e2e/tests/hostChecks.cy.ts
+++ b/vite-vue-microfrontends/e2e/tests/hostChecks.cy.ts
@@ -1,0 +1,99 @@
+import {BaseMethods} from "../../../cypress/common/base";
+import {baseSelectors, selectors} from "../../../cypress/common/selectors";
+import {Constants} from "../../../cypress/fixtures/constants";
+import {CssAttr} from "../../../cypress/types/cssAttr";
+
+const basePage: BaseMethods = new BaseMethods()
+
+const commonButtonsQuantity: number = 2
+
+describe("It checks host app", () => {
+    beforeEach(() => {
+        basePage.openLocalhost(4173)
+    })
+
+    it('Checks console greeting message', () => {
+        basePage.checkInfoInConsole(Constants.commonPhrases.viteSvelteMicroFrontEndsConsoleMessages[2])
+    })
+
+    it('Checks both cards includes button', () => {
+        basePage.checkElementQuantity({
+            selector: baseSelectors.button,
+            quantity: commonButtonsQuantity,
+            waitUntil: true
+        })
+        basePage.checkElementQuantity({
+            parentSelector: selectors.commonCardSelector,
+            selector: baseSelectors.button,
+            quantity: commonButtonsQuantity,
+        })
+    })
+
+    it('Checks both cards button is not disabled', () => {
+        basePage.checkElementQuantity({
+            selector: baseSelectors.button,
+            quantity: commonButtonsQuantity,
+            waitUntil: true
+        })
+        basePage.checkElementState({
+            selector: baseSelectors.button,
+            state: ':disabled',
+            isMultiple: true,
+            jqueryValue: false
+        })
+    })
+
+    it('Checks both cards button shares same color', () => {
+        basePage.checkElementQuantity({
+            selector: baseSelectors.button,
+            quantity: commonButtonsQuantity,
+            waitUntil: true
+        })
+        basePage.checkElementHaveProperty({
+            selector: baseSelectors.button,
+            prop: CssAttr.css,
+            value: Constants.color.orange,
+            isMultiple: true
+        })
+    })
+
+    it('Checks host app card color is set to blue', () => {
+        basePage.checkElementWithTextHaveProperty({
+            selector: selectors.commonCardSelector,
+            text: Constants.elementsText.viteReactMicroFrontendsCardsMessages.hostCard,
+            prop: CssAttr.css,
+            value: Constants.color.blue,
+            checkType: 'contain'
+        })
+    })
+
+    it('Checks remote app card color is set to black', () => {
+        basePage.checkElementQuantity({
+            selector: selectors.commonCardSelector,
+            quantity: commonButtonsQuantity,
+            waitUntil: true
+        })
+        basePage.checkElementWithTextHaveProperty({
+            selector: selectors.commonCardSelector,
+            text: Constants.elementsText.viteReactMicroFrontendsCardsMessages.remoteCard,
+            prop: CssAttr.css,
+            value: Constants.color.black,
+            checkType: 'contain'
+        })
+    })
+
+    it('Checks that host card button text includes counter which changed after click & check value reverted after reload', () => {
+        basePage.checkCounterInButton(baseSelectors.button,
+            Constants.elementsText.viteReactMicroFrontendsButtonsText.hostButton)
+    })
+
+    it('Checks that remote card button text includes counter which changed after click & check value reverted after reload', () => {
+        basePage.checkElementQuantity({
+            selector: selectors.commonCardSelector,
+            quantity: commonButtonsQuantity,
+            waitUntil: true
+        })
+        basePage.checkCounterInButton(baseSelectors.button,
+            Constants.elementsText.viteReactMicroFrontendsButtonsText.remoteButton, commonButtonsQuantity)
+    })
+})

--- a/vite-vue-microfrontends/e2e/tests/runAll.cy.ts
+++ b/vite-vue-microfrontends/e2e/tests/runAll.cy.ts
@@ -1,0 +1,2 @@
+import './hostChecks.cy'
+import './commonChecks.cy'


### PR DESCRIPTION
<img width="341" alt="Screenshot 2023-01-17 at 18 28 53" src="https://user-images.githubusercontent.com/82213036/212956698-e7d74a21-a7a7-424a-9c26-1c676f57cf21.png">
