### PR TITLE
upd: checkChangedWorkspaces.js script

### DIFF
--- a/checkChangedWorkspaces.js
+++ b/checkChangedWorkspaces.js
@@ -1,13 +1,33 @@
 const { exec } = require("child_process");
-exec("npx lerna ls --since=origin/master --json", (error, stdout, stderr) => {
+exec("npx lerna ls --all --json", (error, stdout, stderr) => {
     if (error) {
         console.log(`error: ${error.message}`);
         return;
     }
+
     try {
-      const jsonArray = JSON.parse(stdout);
-      console.log(JSON.stringify({ container: jsonArray.map(x => x.name)}))
+        const allPackages = JSON.parse(stdout);
+        exec("npx lerna ls --all --since=origin/master --json", (error, stdout, stderr) => {
+            if (error) {
+                console.log(`error: ${error.message}`);
+                return;
+            }
+
+            try {
+                const updatedPackages = JSON.parse(stdout);
+                if (stdout.includes("cypress")) {
+                    // TODO filter for "@" added temporary to not to add packages wich are not automated and formated yet.
+                    const newPackages = allPackages.filter(x => !x.name.includes("_") && !updatedPackages.includes(x) && !x.name.includes("cypress") && !x.name.includes("@"));
+                    console.log(JSON.stringify({ container: newPackages.map(x => x.name)}));
+                } else {
+                  console.log(JSON.stringify({ container: updatedPackages.filter(x => !x.name.includes("_") && !x.name.includes("@")).map(x => x.name)
+                    }))
+                }
+            } catch (e) {
+                console.error(e);
+            }
+        });
     } catch (e) {
-      console.error(e)
+        console.error(e);
     }
 });

--- a/cypress/package.json
+++ b/cypress/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "cypress",
+  "version": "0.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "private": true
+}

--- a/package.json
+++ b/package.json
@@ -94,7 +94,8 @@
       "./nextjs-bi-directional/*",
       "./vue-cli/*",
       "./genesis/*",
-      "./umd-federation/*"
+      "./umd-federation/*",
+      "./cypress"
     ],
     "nohoist": [
       "**/@types",


### PR DESCRIPTION
Changes explanations:

The first command that is executed is `npx lerna ls --all --json`, which lists all of the packages in the current Lerna-managed monorepo, in JSON format. The output of this command is passed as the second argument (stdout) of the callback function.

The code then uses a try-catch block to parse the stdout data as a JSON object and assign it to the variable allPackages.

The next command executed is `npx lerna ls --all --since=origin/master --json`, which lists all of the packages that have been updated since the last time the origin/master branch was synced. The output of this command is passed as the second argument (stdout) of the inner callback function.

The code then uses another try-catch block to parse the stdout data as a JSON object and assign it to the variable updatedPackages.

If the output of the second command includes the string "cypress" (cypress workspace changed), then the code filters out all packages that have "_" and "@" in the name, and filters out all packages that are already in the updatedPackages list, and assigns the remaining packages to the variable newPackages. The code then logs the package names to the console in JSON format.

Result run all e2e tests for all automated samples (Updated + triggered by cypress dir change)
<img width="1661" alt="Screenshot 2023-01-26 at 16 17 49" src="https://user-images.githubusercontent.com/55971575/214858815-85c98c7d-9264-4285-a856-af15146d0df8.png">

If the output of the second command doesn't include the string "cypress" (cypress workspace isn't changed), then the code filters out all packages that have "_" and "@" in the name, and logs the package names to the console in JSON format.

In both cases, if an error occurs, the error message is logged to the console.
