### PR TITLE
feat: add dynamic route example in nextjs-ssr

### DIFF
--- a/nextjs-ssr/checkout/pages/p/[...slug].js
+++ b/nextjs-ssr/checkout/pages/p/[...slug].js
@@ -1,0 +1,4 @@
+import PDPPage from 'shop/pdp';
+const PDP = PDPPage;
+PDP.getInitialProps = PDPPage.getInitialProps;
+export default PDP;

--- a/nextjs-ssr/home/pages/p/[...slug].js
+++ b/nextjs-ssr/home/pages/p/[...slug].js
@@ -1,0 +1,4 @@
+import PDPPage from 'shop/pdp';
+const PDP = PDPPage;
+PDP.getInitialProps = PDPPage.getInitialProps;
+export default PDP;

--- a/nextjs-ssr/shop/pages/p/[...slug].js
+++ b/nextjs-ssr/shop/pages/p/[...slug].js
@@ -1,5 +1,9 @@
+import { useRouter } from 'next/router'
+
 export default function PDP() {
-  return <h1>PDP!!!</h1>;
+  const router = useRouter()
+  const { slug } = router.query
+  return <h1>PDP!!! slug: {slug}</h1>;
 }
 PDP.getInitialProps = async () => {
   return {};

--- a/nextjs-ssr/shop/pages/shop.js
+++ b/nextjs-ssr/shop/pages/shop.js
@@ -1,5 +1,15 @@
 import React from 'react';
 import Head from 'next/head';
+import Link from 'next/link';
+
+const productLinks = [
+  { href: '/p/1', label: 'Product 1' },
+  { href: '/p/2', label: 'Product 2' },
+  { href: '/p/3', label: 'Product 3' },
+].map(link => {
+  link.key = `product-link-${link.href}-${link.label}`;
+  return link;
+});
 
 const Shop = props => (
   <div>
@@ -11,6 +21,16 @@ const Shop = props => (
     <div className="hero">
       <h1>Shop Page</h1>
       <h3 className="title">This is a federated page owned by localhost:3002</h3>
+      <ul>
+        {productLinks.map(({ key, href, label }) => (
+          <li key={key}>
+            <Link href={href}>
+              <a>{label}</a>
+            </Link>
+          </li>
+        ))}
+      </ul>
+
     </div>
     <style jsx>{`
       .hero {


### PR DESCRIPTION
`/p/[...slug].js` page was in `shop` app but wasn't reachable from `home` or `checkout`