### PR TITLE
fix : typo in host (cra-react-app-rewired)

### DIFF
--- a/cra-react-app-rewired/host/config-overrides.js
+++ b/cra-react-app-rewired/host/config-overrides.js
@@ -9,7 +9,7 @@ module.exports = function (config, env) {
   config.plugins.push(
     new ModuleFederationPlugin(
       (module.exports = {
-        name: "remote",
+        name: "host",
         remotes: {
           remote: `remote@http://localhost:3001/remoteEntry.js`,
         },


### PR DESCRIPTION
Cra-react-app-rewired project has two projects, host and remote. 
"name : remote" is not suitable for host in config-overrides.js.
This fix will not make novice users confuse to use module federation. Thanks :pleading_face: