### PR TITLE
Update README.md (#1)

### DIFF
--- a/vite-react-simple/README.md
+++ b/vite-react-simple/README.md
@@ -13,8 +13,8 @@ http://localhost:3000
 
 # Running Cypress E2E Tests
 
-To run tests in interactive mode, run  `npm run cypress:debug` from the root directory of the project. It will open Cypress Test Runner and allow to run tests in interactive mode. [More info about "How to run tests"](../../cypress/README.md#how-to-run-tests)
+To run tests in interactive mode, run  `npm run cypress:debug` from the root directory of the project. It will open Cypress Test Runner and allow to run tests in interactive mode. [More info about "How to run tests"](../../master/cypress/README.md#how-to-run-tests)
 
 To build app and run test in headless mode, run `yarn e2e:ci`. It will build app and run tests for this workspace in headless mode. If tets failed cypress will create `cypress` directory in sample root folder with screenshots and videos.
 
-["Best Practices, Rules amd more interesting information here](../../cypress/README.md)
+[Best Practices, Rules and more interesting information here](../../master/cypress/README.md)


### PR DESCRIPTION
Fixed wrong links to the `cypress` folder in the README file of the `vite-react-simple` example.