### PR TITLE
fix: add publicHost to prevent live-reload infinite loop

### DIFF
--- a/angular15-microfrontends-lazy-components/angular.json
+++ b/angular15-microfrontends-lazy-components/angular.json
@@ -171,6 +171,7 @@
           "builder": "ngx-build-plus:dev-server",
           "options": {
             "browserTarget": "mdmf-profile:build",
+            "publicHost": "http://localhost:4201",
             "extraWebpackConfig": "projects/mdmf-profile/webpack.config.js",
             "port": 4201
           },

--- a/angular15-microfrontends-lazy-components/package.json
+++ b/angular15-microfrontends-lazy-components/package.json
@@ -7,8 +7,8 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start:shell": "ng serve mdmf-shell --live-reload false",
-    "start:profile": "ng serve mdmf-profile --live-reload false",
+    "start:shell": "ng serve mdmf-shell",
+    "start:profile": "ng serve mdmf-profile",
     "build:shared": "ng build mdmf-shared",
     "build:shell": "ng build mdmf-shell",
     "build:profile": "ng build mdmf-profile --prod",


### PR DESCRIPTION
This fix allows you to develop in live-reload mode. Without the `publicHost` property in `angular.json`, live reloading would cause the page to reload indefinitely.