### PR TITLE
fix: cli.isMultipleCompiler is not a function

### DIFF
--- a/different-react-versions-16-17-typescript/app1/package.json
+++ b/different-react-versions-16-17-typescript/app1/package.json
@@ -24,7 +24,7 @@
     "serve": "13.0.4",
     "typescript": "4.8.4",
     "webpack": "5.80.0",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.13.3"
   }
 }

--- a/different-react-versions-16-17-typescript/app2/package.json
+++ b/different-react-versions-16-17-typescript/app2/package.json
@@ -24,7 +24,7 @@
     "serve": "13.0.4",
     "typescript": "4.8.4",
     "webpack": "5.80.0",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.13.3"
   }
 }

--- a/different-react-versions-16-17/app1/package.json
+++ b/different-react-versions-16-17/app1/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "5.5.1",
     "serve": "13.0.4",
     "webpack": "5.80.0",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.13.3"
   },
   "scripts": {

--- a/different-react-versions-16-17/app2/package.json
+++ b/different-react-versions-16-17/app2/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "5.5.1",
     "serve": "13.0.4",
     "webpack": "5.80.0",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.13.3"
   },
   "scripts": {

--- a/different-react-versions-16-18/app1/package.json
+++ b/different-react-versions-16-18/app1/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "5.5.1",
     "serve": "13.0.4",
     "webpack": "5.80.0",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.13.3"
   },
   "scripts": {

--- a/different-react-versions-16-18/app2/package.json
+++ b/different-react-versions-16-18/app2/package.json
@@ -10,7 +10,7 @@
     "html-webpack-plugin": "5.5.1",
     "serve": "13.0.4",
     "webpack": "5.80.0",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.13.3"
   },
   "scripts": {

--- a/different-react-versions-typescript/app1/package.json
+++ b/different-react-versions-typescript/app1/package.json
@@ -24,7 +24,7 @@
     "serve": "13.0.4",
     "typescript": "4.8.4",
     "webpack": "5.80.0",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.13.3"
   }
 }

--- a/different-react-versions-typescript/app2/package.json
+++ b/different-react-versions-typescript/app2/package.json
@@ -24,7 +24,7 @@
     "serve": "13.0.4",
     "typescript": "4.8.4",
     "webpack": "5.80.0",
-    "webpack-cli": "4.9.2",
+    "webpack-cli": "4.10.0",
     "webpack-dev-server": "4.13.3"
   }
 }


### PR DESCRIPTION
there has known issue with `webpack-cli@4.9.x` which will throw 'cli.isMultipleCompiler is not a function' error

![image](https://github.com/module-federation/module-federation-examples/assets/41466093/238bc599-b779-443d-8677-da1a8d7d25bd)

related issue: https://github.com/webpack/webpack/issues/15951
