### PR TITLE
fix(nextjs-v13): Remove import that isn't used

### DIFF
--- a/nextjs-v13/shop/pages/_app.js
+++ b/nextjs-v13/shop/pages/_app.js
@@ -1,4 +1,3 @@
-import dynamic from 'next/dynamic';
 import {lazy} from "react"
 const Nav = process.browser ? lazy(
   () => {


### PR DESCRIPTION
Like title says, removes `dynamic` import that isn't used in an example file.