### PR TITLE
fix(typo): update router 1 to router 2

### DIFF
--- a/react-manifest-example/host/src/pages/remote2.tsx
+++ b/react-manifest-example/host/src/pages/remote2.tsx
@@ -8,7 +8,7 @@ const Button = React.lazy(async ()=>{
 
 function Remote2 () {
     return <Suspense fallback={'loading'}>
-        <h2>Remote1 Router</h2>
+        <h2>Remote2 Router</h2>
         <Button />
     </Suspense>;
 }


### PR DESCRIPTION
There's a spelling error in 'react-mainfest-example' where 'Route 2' has been incorrectly written as 'Route 1', and I would like to make the necessary correction.