### PR TITLE
fix(complete-react-case): resolve imports in component-app page

### DIFF
--- a/complete-react-case/component-app/rspack.config.js
+++ b/complete-react-case/component-app/rspack.config.js
@@ -11,6 +11,9 @@ module.exports = {
     publicPath: 'http://localhost:3001/',
     clean: true,
   },
+  resolve: {
+    extensions: [".jsx", ".js", ".json", ".wasm"]
+  },
   experiments: {
     css: true,
   },


### PR DESCRIPTION
Prior to this change loading the component-app at
https://localhost:3001 errors with: `Cannot find module './App'` rspack outputs a suggestion to fix by updating the resolve.extensions config option.