### PR TITLE
fix: add dev.client.port to support hmr

### DIFF
--- a/react-manifest-example/remote1/rsbuild.config.ts
+++ b/react-manifest-example/remote1/rsbuild.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
   },
   dev: {
     // It is necessary to configure assetPrefix, and in the production environment, you need to configure output.assetPrefix
-    assetPrefix: 'http://localhost:3001',
+    assetPrefix: true,
+    client: {
+      port: 3001
+    }
   },
   tools: {
     rspack: (config, { appendPlugins }) => {

--- a/react-manifest-example/remote2/rsbuild.config.ts
+++ b/react-manifest-example/remote2/rsbuild.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
   },
   dev: {
     // It is necessary to configure assetPrefix, and in the production environment, you need to configure output.assetPrefix
-    assetPrefix: 'http://localhost:3002',
+    assetPrefix: true,
+    client: {
+      port: 3002
+    }
   },
   tools: {
     rspack: (config, { appendPlugins }) => {


### PR DESCRIPTION
The hmr failed because rsbuild correct the `server.port` meanings , it not equals `dev.client.port` related pr https://github.com/web-infra-dev/rsbuild/pull/2639
