### PR TITLE
fix: ensure playwright e2e tests pass

### DIFF
--- a/advanced-api/dynamic-remotes-synchronous-imports/e2e/checkDynamicRemotesSynchImportApps.spec.ts
+++ b/advanced-api/dynamic-remotes-synchronous-imports/e2e/checkDynamicRemotesSynchImportApps.spec.ts
@@ -38,7 +38,7 @@ async function waitForDynamicImport(page: Page, timeout: number = 5000) {
 
 async function checkDateFormat(page: Page) {
   // Check for moment.js date display - just look for the Live Time text which indicates moment.js is working
-  const dateElement = page.locator('text=Live Time (via shared moment.js):');
+  const dateElement = page.locator('text=Live Time (via shared moment.js):').first();
   await dateElement.waitFor({ timeout: 5000 });
 }
 

--- a/advanced-api/dynamic-remotes-synchronous-imports/package.json
+++ b/advanced-api/dynamic-remotes-synchronous-imports/package.json
@@ -11,8 +11,8 @@
     "build": "pnpm --filter dynamic-remotes-synchronous-imports_app* --parallel build",
     "serve": "pnpm --filter dynamic-remotes-synchronous-imports_app* --parallel serve",
     "clean": "pnpm --filter dynamic-remotes-synchronous-imports_app* --parallel clean",
-    "e2e:ci": "npx playwright test",
-    "legacy:e2e:ci": "npx playwright test"
+    "e2e:ci": "pnpm exec playwright install --with-deps && pnpm exec playwright test",
+    "legacy:e2e:ci": "pnpm exec playwright install --with-deps && pnpm exec playwright test"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",


### PR DESCRIPTION
## Summary
- install Playwright browsers before running e2e tests
- handle multiple matching elements for Moment.js date text

## Testing
- `pnpm legacy:e2e:ci`


------
https://chatgpt.com/codex/tasks/task_e_689c51379fe48325a6428a4a2a54a434