### PR TITLE
fix: update federated css remotes to React 18 root API

### DIFF
--- a/federated-css/expose-remotes/expose-css-module/src/bootstrap.js
+++ b/federated-css/expose-remotes/expose-css-module/src/bootstrap.js
@@ -1,5 +1,7 @@
 import App from './App';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/federated-css/expose-remotes/expose-css/src/bootstrap.js
+++ b/federated-css/expose-remotes/expose-css/src/bootstrap.js
@@ -1,5 +1,7 @@
 import App from './App';
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 
-ReactDOM.render(<App />, document.getElementById('root'));
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);


### PR DESCRIPTION
## Summary
- replace legacy ReactDOM.render usage in the federated-css remote bootstrap files with React 18's createRoot API
- ensure the remote dev servers mount without legacy warnings while continuing to expose the same components

## Testing
- timeout 600 pnpm e2e
- timeout 600 sh -c 'CI=1 pnpm e2e:ci'

------
https://chatgpt.com/codex/tasks/task_e_68ce9ebebba8832597a5a6ebf39bde87