### PR TITLE
Fix TypeScript e2e header expectation and duplicate test title

### DIFF
--- a/cypress-e2e/fixtures/commonTestData.ts
+++ b/cypress-e2e/fixtures/commonTestData.ts
@@ -2,6 +2,10 @@ import { getRandomTextString } from '../helpers/base-helper';
 import { Constants } from './constants';
 import { baseSelectors, selectors } from '../common/selectors';
 
+const typescriptHeader =
+  Constants.commonConstantsData.typeScript.charAt(0).toUpperCase() +
+  Constants.commonConstantsData.typeScript.slice(1);
+
 export class CommonTestData {
   public static readonly multipleSizeStringsArray = [
     getRandomTextString(10),
@@ -44,12 +48,12 @@ export class CommonTestData {
   public static readonly commonTypeScriptAppsData = [
     {
       host: 3001,
-      header: Constants.commonConstantsData.typeScript.charAt(0).toUpperCase(),
+      header: typescriptHeader,
       appName: Constants.commonConstantsData.commonCountAppNames.app1,
     },
     {
       host: 3002,
-      header: Constants.commonConstantsData.typeScript.charAt(0).toUpperCase(),
+      header: typescriptHeader,
       appName: Constants.commonConstantsData.commonCountAppNames.app2,
     },
   ];

--- a/typescript/e2e/tests/commonChecks.spec.ts
+++ b/typescript/e2e/tests/commonChecks.spec.ts
@@ -54,7 +54,7 @@ test.describe('Typescript', () => {
       await expect(page.locator(baseSelectors.tags.headers.h2)).toHaveText(app.appName);
     });
 
-    test(`checks both apps share ${primaryAppButtons.small}`, async ({ page }) => {
+    test(`checks both apps share ${primaryAppButtons.small} (port: ${app.host})`, async ({ page }) => {
       await navigateToApp(page, app.host);
 
       await expect(page.getByRole('button', { name: primaryAppButtons.small })).toBeVisible();


### PR DESCRIPTION
## Summary
- ensure the TypeScript shared header expectation matches the rendered "Typescript" title
- give the shared button Playwright test a unique per-port name to avoid duplicate titles

## Testing
- pnpm e2e:ci (typescript)
- pnpm prettier:check

------
https://chatgpt.com/codex/tasks/task_e_68cf561475f08325bd4d35b352ef6296