### PR TITLE
Fix Playwright module duplication in vue2-in-vue3 e2e

### DIFF
--- a/vue2-in-vue3/package.json
+++ b/vue2-in-vue3/package.json
@@ -8,9 +8,9 @@
     "build": "pnpm --filter vue2-in-vue3_vue* build",
     "serve": "pnpm --filter vue2-in-vue3_vue* --parallel serve",
     "clean": "pnpm --filter vue2-in-vue3_vue* --parallel clean",
-    "test:e2e": "pnpm exec playwright test",
-    "test:e2e:ui": "pnpm exec playwright test --ui",
-    "e2e:ci": "pnpm exec playwright test --reporter=line"
+    "test:e2e": "node scripts/run-playwright.cjs test",
+    "test:e2e:ui": "node scripts/run-playwright.cjs test --ui",
+    "e2e:ci": "node scripts/run-playwright.cjs test --reporter=line"
   },
   "devDependencies": {
     "@playwright/test": "^1.54.2",

--- a/vue2-in-vue3/scripts/register-playwright-alias.cjs
+++ b/vue2-in-vue3/scripts/register-playwright-alias.cjs
@@ -1,0 +1,30 @@
+const path = require('node:path');
+const { createRequire } = require('node:module');
+
+const requireFromHere = createRequire(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..');
+
+function aliasModule(request) {
+  let localPath;
+  try {
+    localPath = requireFromHere.resolve(request);
+  } catch {
+    return;
+  }
+
+  // Ensure the module is loaded so the cache entry exists.
+  requireFromHere(request);
+
+  try {
+    const rootPath = requireFromHere.resolve(request, { paths: [repoRoot] });
+    if (rootPath !== localPath && require.cache[localPath]) {
+      require.cache[rootPath] = require.cache[localPath];
+    }
+  } catch {
+    // The root dependency might not exist when running this example in
+    // isolation. That's fine; in that case nothing extra is needed.
+  }
+}
+
+aliasModule('@playwright/test');
+aliasModule('playwright');

--- a/vue2-in-vue3/scripts/run-playwright.cjs
+++ b/vue2-in-vue3/scripts/run-playwright.cjs
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+const cli = require.resolve('@playwright/test/cli');
+const aliasHook = path.resolve(__dirname, 'register-playwright-alias.cjs');
+const args = process.argv.slice(2);
+
+const child = spawn(process.execPath, ['--require', aliasHook, cli, ...args], {
+  stdio: 'inherit',
+});
+
+child.on('exit', code => {
+  if (code !== null) {
+    process.exit(code);
+  }
+});


### PR DESCRIPTION
## Summary
- ensure the shared playwright helpers resolve to the same module instance when the vue2-in-vue3 example installs its own dependencies
- add a wrapper script that preloads the alias before invoking the playwright CLI and update package scripts to use it

## Testing
- pnpm e2e:ci

------
https://chatgpt.com/codex/tasks/task_e_68d322e568048325817057190361e058