### PR TITLE
chore: remove root TypeScript fallback

### DIFF
--- a/angular-universal-ssr/client-app/package.json
+++ b/angular-universal-ssr/client-app/package.json
@@ -39,7 +39,7 @@
     "sass-loader": "14.2.1",
     "ts-node": "10.9.2",
     "tslint": "6.1.3",
-    "typescript": "5.5.3",
+    "typescript": "4.9.5",
     "webpack": "5.105.3",
     "webpack-cli": "5.1.4"
   }

--- a/angular-universal-ssr/host-app/package.json
+++ b/angular-universal-ssr/host-app/package.json
@@ -43,7 +43,7 @@
     "sass-loader": "14.2.1",
     "ts-node": "10.9.2",
     "tslint": "6.1.3",
-    "typescript": "5.5.3",
+    "typescript": "4.9.5",
     "webpack": "5.105.3",
     "webpack-cli": "5.1.4"
   }

--- a/dynamic-remotes-node-typescript/host/package.json
+++ b/dynamic-remotes-node-typescript/host/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "@module-federation/node": "2.7.32",
     "ts-loader": "^9.5.1",
+    "typescript": "5.6.2",
     "webpack": "5.105.3",
     "webpack-cli": "5.1.4"
   }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "packageExtensions": {
       "@analogjs/vite-plugin-angular": {
         "peerDependencies": {
+          "@angular/compiler-cli": "^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0",
           "typescript": ">=5.8 <6.0"
         }
       }
@@ -61,8 +62,7 @@
     "mocha": "10.6.0",
     "prettier": "3.3.3",
     "pretty-quick": "4.0.0",
-    "semver": "7.6.3",
-    "typescript": "5.5.3"
+    "semver": "7.6.3"
   },
   "scripts": {
     "list:all": "pnpm list --filter \"*\" --only-projects --depth -1 --json",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   '@playwright/test': 1.58.2
   playwright: 1.58.2
 
-packageExtensionsChecksum: sha256-ViaQPHZU5dZAExqN/P8Sr1kPUQ5KSrlRNFgK/jWwmc4=
+packageExtensionsChecksum: sha256-p/Jhmx9ROBXyexuKOyHh4/rUVL5GluF52dEsdU0j+r0=
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: 9.0.11
       jest:
         specifier: 29.7.0
-        version: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3))
+        version: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3))
       js-yaml:
         specifier: 4.1.0
         version: 4.1.0
@@ -61,7 +61,7 @@ importers:
         version: 2.0.1
       lerna:
         specifier: 8.1.8
-        version: 8.1.8(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(babel-plugin-macros@3.1.0)(encoding@0.1.13)
+        version: 8.1.8(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(babel-plugin-macros@3.1.0)(encoding@0.1.13)
       lint-staged:
         specifier: ^15.5.2
         version: 15.5.2
@@ -77,9 +77,6 @@ importers:
       semver:
         specifier: 7.6.3
         version: 7.6.3
-      typescript:
-        specifier: 5.5.3
-        version: 5.5.3
 
   advanced-api/automatic-vendor-sharing:
     devDependencies:
@@ -110,7 +107,7 @@ importers:
         version: 7.28.5(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -168,7 +165,7 @@ importers:
         version: 7.28.5(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -247,7 +244,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/retry-plugin':
         specifier: 0.17.1
         version: 0.17.1
@@ -311,7 +308,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/retry-plugin':
         specifier: 0.17.1
         version: 0.17.1
@@ -378,7 +375,7 @@ importers:
         version: 7.28.5(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -436,7 +433,7 @@ importers:
         version: 7.28.5(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -485,7 +482,7 @@ importers:
         version: 7.28.5(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/runtime':
         specifier: 2.0.1
         version: 2.0.1
@@ -552,7 +549,7 @@ importers:
         version: 7.28.5(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -622,7 +619,7 @@ importers:
         version: 7.28.5(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -716,16 +713,16 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 15.2.10
-        version: 15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@5.5.3)(webpack-cli@5.1.4)
+        version: 15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@4.9.5)(webpack-cli@5.1.4)
       '@angular/cli':
         specifier: 15.2.10
         version: 15.2.10(chokidar@3.5.3)
       '@angular/compiler-cli':
         specifier: 15.2.10
-        version: 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3)
+        version: 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5)
       '@ngtools/webpack':
         specifier: 15.2.11
-        version: 15.2.11(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.105.3)
+        version: 15.2.11(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(typescript@4.9.5)(webpack@5.105.3)
       '@types/node':
         specifier: 18.19.39
         version: 18.19.39
@@ -743,13 +740,13 @@ importers:
         version: 14.2.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(sass-embedded@1.97.3)(sass@1.58.1)(webpack@5.105.3)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.39)(typescript@5.5.3)
+        version: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.39)(typescript@4.9.5)
       tslint:
         specifier: 6.1.3
-        version: 6.1.3(typescript@5.5.3)
+        version: 6.1.3(typescript@4.9.5)
       typescript:
-        specifier: 5.5.3
-        version: 5.5.3
+        specifier: 4.9.5
+        version: 4.9.5
       webpack:
         specifier: 5.105.3
         version: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
@@ -804,19 +801,19 @@ importers:
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 15.2.10
-        version: 15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@5.5.3)(webpack-cli@5.1.4)
+        version: 15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@4.9.5)(webpack-cli@5.1.4)
       '@angular/cli':
         specifier: 15.2.10
         version: 15.2.10(chokidar@3.6.0)
       '@angular/compiler-cli':
         specifier: 15.2.10
-        version: 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3)
+        version: 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5)
       '@ngtools/webpack':
         specifier: 15.2.11
-        version: 15.2.11(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.105.3)
+        version: 15.2.11(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(typescript@4.9.5)(webpack@5.105.3)
       '@nguniversal/builders':
         specifier: 16.2.0
-        version: 16.2.0(@angular-devkit/build-angular@15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@5.5.3)(webpack-cli@5.1.4))(@angular/common@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))(@types/express@4.17.25)(chokidar@3.6.0)(typescript@5.5.3)
+        version: 16.2.0(@angular-devkit/build-angular@15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@4.9.5)(webpack-cli@5.1.4))(@angular/common@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))(@types/express@4.17.25)(chokidar@3.6.0)(typescript@4.9.5)
       clean-webpack-plugin:
         specifier: 4.0.0
         version: 4.0.0(webpack@5.105.3)
@@ -831,13 +828,13 @@ importers:
         version: 14.2.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(sass-embedded@1.97.3)(sass@1.97.3)(webpack@5.105.3)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.5.3)
+        version: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@4.9.5)
       tslint:
         specifier: 6.1.3
-        version: 6.1.3(typescript@5.5.3)
+        version: 6.1.3(typescript@4.9.5)
       typescript:
-        specifier: 5.5.3
-        version: 5.5.3
+        specifier: 4.9.5
+        version: 4.9.5
       webpack:
         specifier: 5.105.3
         version: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
@@ -907,10 +904,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1004,10 +1001,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.21)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1092,7 +1089,7 @@ importers:
         version: 2.54.6
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@0.4.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
+        version: 2.0.1(@rspack/core@0.4.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.3))(esbuild@0.17.19))
       husky:
         specifier: 9.0.11
         version: 9.0.11
@@ -1135,7 +1132,7 @@ importers:
         version: 2.54.6
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       husky:
         specifier: 9.0.11
         version: 9.0.11
@@ -1171,7 +1168,7 @@ importers:
         version: 2.69.5(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6)))(react@18.3.1)
       '@module-federation/modern-js':
         specifier: 2.70.6
-        version: 2.70.6(@rsbuild/core@1.6.15)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+        version: 2.70.6(@rsbuild/core@1.6.15)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
       react:
         specifier: ~18.3.1
         version: 18.3.1
@@ -1196,7 +1193,7 @@ importers:
         version: 2.69.5
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
       husky:
         specifier: 9.0.11
         version: 9.0.11
@@ -1217,7 +1214,7 @@ importers:
         version: 2.69.5(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))))(react@18.3.1)
       '@module-federation/modern-js':
         specifier: 2.70.6
-        version: 2.70.6(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.70.6(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       react:
         specifier: ~18.3.1
         version: 18.3.1
@@ -1242,7 +1239,7 @@ importers:
         version: 2.69.5
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       husky:
         specifier: 9.0.11
         version: 9.0.11
@@ -1338,10 +1335,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -1393,7 +1390,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1442,7 +1439,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1482,7 +1479,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1539,7 +1536,7 @@ importers:
         version: 4.12.4(@types/react@18.3.10)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1594,7 +1591,7 @@ importers:
         version: 4.12.4(@types/react@18.3.10)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1639,7 +1636,7 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1678,7 +1675,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1726,7 +1723,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1835,7 +1832,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/runtime':
         specifier: 2.0.1
         version: 2.0.1
@@ -1868,7 +1865,7 @@ importers:
         version: 4.12.4(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1920,7 +1917,7 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -1966,7 +1963,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
         version: 0.5.15(@types/webpack@5.28.0(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4))(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.105.3)
@@ -2020,7 +2017,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
         version: 0.5.15(@types/webpack@5.28.0(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4))(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.105.3)
@@ -2084,7 +2081,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@rsbuild/core':
         specifier: 1.7.3
         version: 1.7.3
@@ -2106,7 +2103,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@rsbuild/core':
         specifier: 1.7.3
         version: 1.7.3
@@ -2143,7 +2140,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -2195,7 +2192,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -2288,7 +2285,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -2349,7 +2346,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -2419,7 +2416,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -2501,7 +2498,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -2574,7 +2571,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -2609,7 +2606,7 @@ importers:
     dependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       react:
         specifier: 16.14.0
         version: 16.14.0
@@ -2670,7 +2667,7 @@ importers:
     dependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       react:
         specifier: 17.0.2
         version: 17.0.2
@@ -2749,7 +2746,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -2798,7 +2795,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -2853,7 +2850,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -2899,7 +2896,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -2960,7 +2957,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -3021,7 +3018,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -3079,7 +3076,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -3128,7 +3125,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -3161,13 +3158,13 @@ importers:
     dependencies:
       '@module-federation/dts-plugin':
         specifier: 2.0.1
-        version: 2.0.1(typescript@5.6.2)
+        version: 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)
       '@module-federation/runtime':
         specifier: 2.0.1
         version: 2.0.1
@@ -3213,13 +3210,13 @@ importers:
     dependencies:
       '@module-federation/dts-plugin':
         specifier: 2.0.1
-        version: 2.0.1(typescript@5.6.2)
+        version: 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)
       '@module-federation/runtime':
         specifier: 2.0.1
         version: 2.0.1
@@ -3265,10 +3262,13 @@ importers:
     devDependencies:
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.0.1)(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)
       ts-loader:
         specifier: ^9.5.1
-        version: 9.5.4(typescript@5.9.3)(webpack@5.105.3)
+        version: 9.5.4(typescript@5.6.2)(webpack@5.105.3)
+      typescript:
+        specifier: 5.6.2
+        version: 5.6.2
       webpack:
         specifier: 5.105.3
         version: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
@@ -3280,7 +3280,7 @@ importers:
     devDependencies:
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       webpack:
         specifier: 5.105.3
         version: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
@@ -3320,7 +3320,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -3372,7 +3372,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -3430,7 +3430,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -3515,10 +3515,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -3579,10 +3579,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -3640,10 +3640,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -3698,10 +3698,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -3765,10 +3765,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -3829,10 +3829,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -3899,7 +3899,7 @@ importers:
         version: 2.1.4(react@18.3.1)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -3990,10 +3990,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -4084,10 +4084,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -4178,10 +4178,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -4272,10 +4272,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -4366,10 +4366,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -4460,10 +4460,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -4502,7 +4502,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -4536,7 +4536,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -4570,7 +4570,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -4604,7 +4604,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -4638,7 +4638,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       css-loader:
         specifier: ^7.1.2
         version: 7.1.2(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
@@ -4688,7 +4688,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -4737,7 +4737,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -4786,7 +4786,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -4835,7 +4835,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -4884,7 +4884,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -4933,7 +4933,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -4982,7 +4982,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -5022,7 +5022,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -5065,7 +5065,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5117,7 +5117,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5166,7 +5166,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5221,7 +5221,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5279,7 +5279,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5328,7 +5328,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5386,7 +5386,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5450,7 +5450,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5514,7 +5514,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5581,7 +5581,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5642,7 +5642,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5721,7 +5721,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/runtime':
         specifier: 2.0.1
         version: 2.0.1
@@ -5770,7 +5770,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/runtime':
         specifier: 2.0.1
         version: 2.0.1
@@ -5825,7 +5825,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -5876,7 +5876,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -5919,7 +5919,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -5953,7 +5953,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -5987,7 +5987,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -6113,7 +6113,7 @@ importers:
     devDependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(next@12.3.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(next@12.3.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@types/node':
         specifier: 20.9.0
         version: 20.9.0
@@ -6171,7 +6171,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -6250,7 +6250,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -6353,10 +6353,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@types/express':
         specifier: 4.17.21
         version: 4.17.21
@@ -6444,10 +6444,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@types/express':
         specifier: 4.17.21
         version: 4.17.21
@@ -6544,10 +6544,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@types/express':
         specifier: 4.17.21
         version: 4.17.21
@@ -6632,10 +6632,10 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@types/express':
         specifier: 4.17.21
         version: 4.17.21
@@ -6686,7 +6686,7 @@ importers:
         version: 2.69.5(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))))(react@18.3.1)
       '@module-federation/modern-js':
         specifier: 2.70.6
-        version: 2.70.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.70.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       react:
         specifier: ~18.3.1
         version: 18.3.1
@@ -6741,7 +6741,7 @@ importers:
         version: 2.69.5(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))))(react@18.3.1)
       '@module-federation/modern-js':
         specifier: 2.70.6
-        version: 2.70.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.70.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -6796,7 +6796,7 @@ importers:
         version: 2.69.5(react-dom@18.3.1(react@18.3.1))(react-server-dom-webpack@19.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))))(react@18.3.1)
       '@module-federation/modern-js':
         specifier: 2.70.6
-        version: 2.70.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.70.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       react:
         specifier: ~18.3.1
         version: 18.3.1
@@ -6981,7 +6981,7 @@ importers:
         version: 20.3.18(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       '@module-federation/vite':
         specifier: 1.13.5
-        version: 1.13.5(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(less@4.4.0)(sass-embedded@1.97.3)(sass@1.90.0)(stylus@0.62.0)(terser@5.46.0)(yaml@2.8.2))
+        version: 1.13.5(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(less@4.4.0)(sass-embedded@1.97.3)(sass@1.90.0)(stylus@0.62.0)(terser@5.46.0)(yaml@2.8.2))(vue-tsc@1.8.27(typescript@5.9.3))
       rxjs:
         specifier: ~7.8.2
         version: 7.8.2
@@ -6994,7 +6994,7 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: 2.3.1
-        version: 2.3.1(@angular-devkit/build-angular@20.3.21(8c01346b7a36de487db43237896426cc))(@angular/build@20.3.21(df73556e4276f8bbdf3821d7292c36bb))(typescript@5.9.3)
+        version: 2.3.1(@angular-devkit/build-angular@20.3.21(8c01346b7a36de487db43237896426cc))(@angular/build@20.3.21(df73556e4276f8bbdf3821d7292c36bb))(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.9.3))(typescript@5.9.3)
       '@angular-devkit/build-angular':
         specifier: 20.3.21
         version: 20.3.21(8c01346b7a36de487db43237896426cc)
@@ -7036,7 +7036,7 @@ importers:
         version: 20.3.18(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/compiler@20.3.18)(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(@angular/platform-browser@20.3.18(@angular/animations@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(@angular/common@20.3.18(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1))(rxjs@7.8.2))(@angular/core@20.3.18(@angular/compiler@20.3.18)(rxjs@7.8.2)(zone.js@0.15.1)))(rxjs@7.8.2)
       '@module-federation/vite':
         specifier: 1.13.5
-        version: 1.13.5(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0)(yaml@2.8.2))
+        version: 1.13.5(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0)(yaml@2.8.2))(vue-tsc@1.8.27(typescript@5.9.3))
       rxjs:
         specifier: ~7.8.2
         version: 7.8.2
@@ -7049,7 +7049,7 @@ importers:
     devDependencies:
       '@analogjs/vite-plugin-angular':
         specifier: 2.3.1
-        version: 2.3.1(@angular-devkit/build-angular@20.3.21(2e435117984c53c2e4e2eef39d8e4a58))(@angular/build@20.3.21(604674133aff0acfeb79e087a907d188))(typescript@5.9.3)
+        version: 2.3.1(@angular-devkit/build-angular@20.3.21(2e435117984c53c2e4e2eef39d8e4a58))(@angular/build@20.3.21(604674133aff0acfeb79e087a907d188))(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.9.3))(typescript@5.9.3)
       '@angular-devkit/build-angular':
         specifier: 20.3.21
         version: 20.3.21(2e435117984c53c2e4e2eef39d8e4a58)
@@ -7098,7 +7098,7 @@ importers:
         version: 2.66.0
       '@module-federation/modern-js':
         specifier: 2.1.0
-        version: 2.1.0(@rsbuild/core@1.2.19)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
+        version: 2.1.0(@rsbuild/core@1.2.19)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
       '@types/node':
         specifier: ~16.11.7
         version: 16.11.68
@@ -7122,7 +7122,7 @@ importers:
         version: 2.68.19(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       '@module-federation/modern-js':
         specifier: 2.1.0
-        version: 2.1.0(@rsbuild/core@1.6.1)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react-router-dom@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-router@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+        version: 2.1.0(@rsbuild/core@1.6.1)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react-router-dom@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-router@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
       react:
         specifier: ~17
         version: 17.0.2
@@ -7159,7 +7159,7 @@ importers:
         version: 2.68.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@module-federation/modern-js':
         specifier: 2.1.0
-        version: 2.1.0(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
+        version: 2.1.0(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -7221,13 +7221,13 @@ importers:
         version: 11.11.4(@types/react@18.3.10)(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@module-federation/native-federation-tests':
         specifier: 0.6.0
         version: 0.6.0(@swc/core@1.15.8(@swc/helpers@0.5.18))(jiti@2.6.1)(postcss@8.4.47)(typescript@5.5.3)(yaml@2.8.2)
       '@module-federation/native-federation-typescript':
         specifier: 0.6.0
-        version: 0.6.0(typescript@5.5.3)
+        version: 0.6.0(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -7315,7 +7315,7 @@ importers:
         version: 0.6.0(@swc/core@1.15.8(@swc/helpers@0.5.18))(jiti@2.6.1)(postcss@8.5.6)(typescript@5.5.3)(yaml@2.8.2)
       '@module-federation/native-federation-typescript':
         specifier: 0.6.0
-        version: 0.6.0(typescript@5.5.3)
+        version: 0.6.0(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -7391,7 +7391,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -7412,7 +7412,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime':
         specifier: 2.0.1
         version: 2.0.1
@@ -7436,7 +7436,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime':
         specifier: 2.0.1
         version: 2.0.1
@@ -7476,7 +7476,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(next@14.2.13(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.24.7)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(next@14.2.13(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.24.7)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@tanstack/react-query':
         specifier: ^4.42.0
         version: 4.42.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7609,7 +7609,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -7630,7 +7630,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -7651,7 +7651,7 @@ importers:
     dependencies:
       '@module-federation/nextjs-mf':
         specifier: 8.8.56
-        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -7706,7 +7706,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -7752,7 +7752,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       css-loader:
         specifier: 7.1.2
         version: 7.1.2(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(webpack@5.105.3)
@@ -7806,7 +7806,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -7840,7 +7840,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       webpack:
         specifier: 5.105.3
         version: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
@@ -7861,7 +7861,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.15
         version: 0.5.15(@types/webpack@5.28.0(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4))(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-dev-server@5.0.4)(webpack-hot-middleware@2.26.1)(webpack@5.105.3)
@@ -7900,7 +7900,7 @@ importers:
         version: 5.6.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       antd:
         specifier: ^5.29.3
         version: 5.29.3(date-fns@2.30.0)(luxon@3.7.2)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7934,7 +7934,7 @@ importers:
     dependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       antd:
         specifier: ^5.29.3
         version: 5.29.3(date-fns@2.30.0)(luxon@3.7.2)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -7968,7 +7968,7 @@ importers:
     dependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       antd:
         specifier: ^5.29.3
         version: 5.29.3(date-fns@2.30.0)(luxon@3.7.2)(moment@2.30.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8002,7 +8002,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       express:
         specifier: ^4.22.1
         version: 4.22.1
@@ -8054,7 +8054,7 @@ importers:
     devDependencies:
       '@module-federation/storybook-addon':
         specifier: 3.0.6
-        version: 3.0.6(dd35e7cd74fcdb2069ae983379e76c3b)
+        version: 3.0.6(fd2068114f0df00188ff3db796f5fd0a)
       '@module-federation/utilities':
         specifier: 3.1.26
         version: 3.1.26(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.23.0))
@@ -8139,7 +8139,7 @@ importers:
     dependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       react:
         specifier: ^18.3.1
         version: 18.3.1
@@ -8183,7 +8183,7 @@ importers:
     devDependencies:
       '@module-federation/vite':
         specifier: 1.11.0
-        version: 1.11.0(rollup@4.59.0)(typescript@5.9.3)(vite@5.3.3(@types/node@25.1.0)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0))
+        version: 1.11.0(rollup@4.59.0)(typescript@5.9.3)(vite@5.3.3(@types/node@25.1.0)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0))(vue-tsc@1.8.27(typescript@5.9.3))
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.3.2(vite@5.3.3(@types/node@25.1.0)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0))
@@ -8238,7 +8238,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -8278,7 +8278,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -8333,10 +8333,10 @@ importers:
         version: 7.24.7
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@remix-run/dev':
         specifier: 2.10.2
         version: 2.10.2(@remix-run/react@2.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))(typescript@5.9.3)(vite@5.4.21(@types/node@25.1.0)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0))
@@ -8403,10 +8403,10 @@ importers:
         version: 7.24.7
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@remix-run/dev':
         specifier: 2.10.2
         version: 2.10.2(@remix-run/react@2.17.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3))(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3))(typescript@5.9.3)(vite@5.4.21(@types/node@25.1.0)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0))
@@ -8469,7 +8469,7 @@ importers:
         version: 4.12.4(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: ^9.2.1
         version: 9.2.1(@babel/core@7.29.0)(webpack@5.105.3)
@@ -8515,7 +8515,7 @@ importers:
         version: 4.12.4(@types/react@18.3.10)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -8560,7 +8560,7 @@ importers:
         version: 7.28.5(@babel/core@7.29.0)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -8599,7 +8599,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -8647,7 +8647,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -8714,7 +8714,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -8766,7 +8766,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -8806,7 +8806,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -8875,7 +8875,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@module-federation/runtime':
         specifier: 2.5.1
         version: 2.5.1(node-fetch@3.3.2)
@@ -8927,7 +8927,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@module-federation/runtime':
         specifier: 2.5.1
         version: 2.5.1(node-fetch@3.3.2)
@@ -8988,7 +8988,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2)
       esbuild-loader:
         specifier: 4.2.0
         version: 4.2.0(webpack@5.107.2)
@@ -9031,7 +9031,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2)
       esbuild-loader:
         specifier: 4.2.0
         version: 4.2.0(webpack@5.107.2)
@@ -9074,7 +9074,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2)
       esbuild-loader:
         specifier: 4.2.0
         version: 4.2.0(webpack@5.107.2)
@@ -9146,7 +9146,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@rspack/cli':
         specifier: 2.0.8
         version: 2.0.8(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(@rspack/dev-server@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(selfsigned@5.5.0))
@@ -9195,7 +9195,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@rspack/cli':
         specifier: 2.0.8
         version: 2.0.8(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(@rspack/dev-server@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(selfsigned@5.5.0))
@@ -9256,7 +9256,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@module-federation/runtime':
         specifier: 2.5.1
         version: 2.5.1(node-fetch@3.3.2)
@@ -9308,7 +9308,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@module-federation/runtime':
         specifier: 2.5.1
         version: 2.5.1(node-fetch@3.3.2)
@@ -9375,7 +9375,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@module-federation/runtime':
         specifier: 2.5.1
         version: 2.5.1(node-fetch@3.3.2)
@@ -9427,7 +9427,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@module-federation/runtime':
         specifier: 2.5.1
         version: 2.5.1(node-fetch@3.3.2)
@@ -9479,7 +9479,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@module-federation/runtime':
         specifier: 2.5.1
         version: 2.5.1(node-fetch@3.3.2)
@@ -9536,7 +9536,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       autoprefixer:
         specifier: 10.4.19
         version: 10.4.19(postcss@8.4.47)
@@ -9757,7 +9757,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@module-federation/runtime':
         specifier: 2.5.1
         version: 2.5.1(node-fetch@3.3.2)
@@ -9809,7 +9809,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.5.1
-        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)
+        version: 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)
       '@module-federation/runtime':
         specifier: 2.5.1
         version: 2.5.1(node-fetch@3.3.2)
@@ -9864,7 +9864,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       esbuild-loader:
         specifier: 4.2.0
         version: 4.2.0(webpack@5.105.3)
@@ -9885,7 +9885,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@wasm-tool/wasm-pack-plugin':
         specifier: 1.7.0
         version: 1.7.0
@@ -9931,7 +9931,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -9971,7 +9971,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10017,7 +10017,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@playwright/test':
         specifier: 1.58.2
         version: 1.58.2
@@ -10069,7 +10069,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10106,7 +10106,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10154,7 +10154,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10194,7 +10194,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10261,7 +10261,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10313,7 +10313,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10371,7 +10371,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10441,7 +10441,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10499,7 +10499,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10557,7 +10557,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10591,7 +10591,7 @@ importers:
         version: 7.24.7
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -10637,7 +10637,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@vue/runtime-dom':
         specifier: 3.4.31
         version: 3.4.31
@@ -10695,7 +10695,7 @@ importers:
         version: 7.24.7(@babel/core@7.29.0)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@vue/runtime-dom':
         specifier: 3.4.31
         version: 3.4.31
@@ -10737,10 +10737,10 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -10764,10 +10764,10 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -10791,10 +10791,10 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@rspack/cli':
         specifier: 1.7.6
         version: 1.7.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(@types/express@4.17.25)(webpack-cli@5.1.4)(webpack@5.105.3)
@@ -10861,7 +10861,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@types/express':
         specifier: 4.17.21
         version: 4.17.21
@@ -10937,7 +10937,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/node':
         specifier: 2.7.32
-        version: 2.7.32(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.7.32(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@types/express':
         specifier: 4.17.21
         version: 4.17.21
@@ -10998,7 +10998,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       babel-loader:
         specifier: 9.1.3
         version: 9.1.3(@babel/core@7.24.7)(webpack@5.105.3)
@@ -11056,7 +11056,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -11108,7 +11108,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -11163,7 +11163,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -11215,7 +11215,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -11279,7 +11279,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -11331,7 +11331,7 @@ importers:
         version: 7.24.7(@babel/core@7.24.7)
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       '@types/react':
         specifier: 18.3.10
         version: 18.3.10
@@ -11385,7 +11385,7 @@ importers:
     dependencies:
       '@module-federation/typescript':
         specifier: 3.1.3
-        version: 3.1.3(encoding@0.1.13)(next@16.1.6(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.105.3)
+        version: 3.1.3(encoding@0.1.13)(next@16.1.6(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -11434,7 +11434,7 @@ importers:
     dependencies:
       '@module-federation/typescript':
         specifier: 3.1.3
-        version: 3.1.3(encoding@0.1.13)(next@16.1.6(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.105.3)
+        version: 3.1.3(encoding@0.1.13)(next@16.1.6(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -11582,7 +11582,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@vue/cli-plugin-babel':
         specifier: 5.0.8
         version: 5.0.8(@swc/core@1.15.8(@swc/helpers@0.5.18))(@vue/cli-service@5.0.8(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@vue/compiler-sfc@3.5.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.23)(prettier@3.3.3)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(underscore@1.12.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.5.0))(core-js@3.47.0)(encoding@0.1.13)(postcss@8.4.47)(vue@2.7.16)
@@ -11625,7 +11625,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@vue/cli-plugin-babel':
         specifier: 5.0.8
         version: 5.0.8(@swc/core@1.15.8(@swc/helpers@0.5.18))(@vue/cli-service@5.0.8(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@vue/compiler-sfc@3.5.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.23)(prettier@3.3.3)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(underscore@1.12.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.5.0))(core-js@3.47.0)(encoding@0.1.13)(vue@2.7.16)
@@ -11665,7 +11665,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@vue/cli-plugin-babel':
         specifier: 5.0.8
         version: 5.0.8(@swc/core@1.15.8(@swc/helpers@0.5.18))(@vue/cli-service@5.0.8(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@vue/compiler-sfc@3.5.27)(ejs@3.1.10)(encoding@0.1.13)(handlebars@4.7.8)(lodash@4.17.23)(prettier@3.3.3)(pug@3.0.3)(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(underscore@1.12.1)(vue-template-compiler@2.7.16)(vue@2.7.16)(webpack-sources@3.5.0))(core-js@3.47.0)(encoding@0.1.13)(vue@2.7.16)
@@ -11720,7 +11720,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       css-loader:
         specifier: 7.1.2
         version: 7.1.2(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(webpack@5.105.3)
@@ -11772,7 +11772,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       css-loader:
         specifier: 7.1.2
         version: 7.1.2(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(webpack@5.105.3)
@@ -11818,7 +11818,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@typescript-eslint/eslint-plugin':
         specifier: 7.15.0
         version: 7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.3))(eslint@9.6.0)(typescript@5.5.3)
@@ -11885,7 +11885,7 @@ importers:
     devDependencies:
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@typescript-eslint/eslint-plugin':
         specifier: 7.15.0
         version: 7.15.0(@typescript-eslint/parser@7.15.0(eslint@9.6.0)(typescript@5.5.3))(eslint@9.6.0)(typescript@5.5.3)
@@ -11952,7 +11952,7 @@ importers:
         version: 7.24.7
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@vue/compiler-sfc':
         specifier: 3.4.31
         version: 3.4.31
@@ -12001,7 +12001,7 @@ importers:
         version: 7.24.7
       '@module-federation/enhanced':
         specifier: 2.0.1
-        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+        version: 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@vue/compiler-sfc':
         specifier: 3.4.31
         version: 3.4.31
@@ -12071,6 +12071,7 @@ packages:
     peerDependencies:
       '@angular-devkit/build-angular': ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
       '@angular/build': ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
+      '@angular/compiler-cli': ^17.0.0 || ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
       typescript: '>=5.8 <6.0'
     peerDependenciesMeta:
       '@angular-devkit/build-angular':
@@ -22298,6 +22299,15 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  '@volar/language-core@1.11.1':
+    resolution: {integrity: sha512-dOcNn3i9GgZAcJt43wuaEykSluAuOkQgzni1cuxLxTV0nJKanQztp7FxyswdRILaKH+P2XZMPRp2S4MV/pElCw==}
+
+  '@volar/source-map@1.11.1':
+    resolution: {integrity: sha512-hJnOnwZ4+WT5iupLRnuzbULZ42L7BWWPMmruzwtLhJfpDVoZLjNBxHDi2sY2bgZXCKlpU5XcsMFoYrsQmPhfZg==}
+
+  '@volar/typescript@1.11.1':
+    resolution: {integrity: sha512-iU+t2mas/4lYierSnoFOeRFQUhAEMgsFuQxoxvwn5EdQopw43j+J27a4lt9LMInx1gLJBC6qL14WYGlgymaSMQ==}
+
   '@vue/babel-helper-vue-jsx-merge-props@1.4.0':
     resolution: {integrity: sha512-JkqXfCkUDp4PIlFdDQ0TdXoIejMtTHP67/pvxlgeY+u5k3LEdKuWZ3LK6xkxo52uDoABIVyRwqVkfLQJhk7VBA==}
 
@@ -22501,6 +22511,14 @@ packages:
       eslint: ^8.56.0
       eslint-plugin-vue: ^9.0.0
       typescript: '>=4.7.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@vue/language-core@1.8.27':
+    resolution: {integrity: sha512-L8Kc27VdQserNaCUNiSFdDl9LWT24ly8Hpwf1ECy3aFb9m6bDhBGQYOujDm21N7EW3moKIOKEanQwe1q5BK+mA==}
+    peerDependencies:
+      typescript: '*'
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -24319,6 +24337,9 @@ packages:
 
   compute-scroll-into-view@3.1.1:
     resolution: {integrity: sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw==}
+
+  computeds@0.0.1:
+    resolution: {integrity: sha512-7CEBgcMjVmitjYo5q8JTJVra6X5mQ20uTThdK+0kR7UEaDrAWEQcRiBtWJzga4eRpP6afNwwLsX2SET2JhVB1Q==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -29937,6 +29958,9 @@ packages:
 
   msgpackr@1.12.1:
     resolution: {integrity: sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ==}
+
+  muggle-string@0.3.1:
+    resolution: {integrity: sha512-ckmWDJjphvd/FvZawgygcUeQCxzvohjFO5RxTjj4eq8kw359gFF3E1brjfI+viLMxss5JrHTDRHZvu2/tuy0Qg==}
 
   multicast-dns@7.2.5:
     resolution: {integrity: sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==}
@@ -36094,6 +36118,12 @@ packages:
   vue-template-es2015-compiler@1.9.1:
     resolution: {integrity: sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==}
 
+  vue-tsc@1.8.27:
+    resolution: {integrity: sha512-WesKCAZCRAbmmhuGl3+VrdWItEvfoFIPXOvUJkjULi+x+6G/Dy69yO3TBRJDr9eUlmsNAwVmxsNZxvHKzbkKdg==}
+    hasBin: true
+    peerDependencies:
+      typescript: '*'
+
   vue@2.7.16:
     resolution: {integrity: sha512-4gCtFXaAA3zYZdTp5s4Hl2sozuySsgz4jy1EnpBHNfpMa9dK1ZCG7viqBPCwXtmgc8nHqUsAu3G4gtmXkkY3Sw==}
     deprecated: Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.
@@ -37026,8 +37056,9 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
 
-  '@analogjs/vite-plugin-angular@2.3.1(@angular-devkit/build-angular@20.3.21(2e435117984c53c2e4e2eef39d8e4a58))(@angular/build@20.3.21(604674133aff0acfeb79e087a907d188))(typescript@5.9.3)':
+  '@analogjs/vite-plugin-angular@2.3.1(@angular-devkit/build-angular@20.3.21(2e435117984c53c2e4e2eef39d8e4a58))(@angular/build@20.3.21(604674133aff0acfeb79e087a907d188))(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
+      '@angular/compiler-cli': 20.3.18(@angular/compiler@20.3.18)(typescript@5.9.3)
       tinyglobby: 0.2.15
       ts-morph: 21.0.1
       typescript: 5.9.3
@@ -37035,8 +37066,9 @@ snapshots:
       '@angular-devkit/build-angular': 20.3.21(2e435117984c53c2e4e2eef39d8e4a58)
       '@angular/build': 20.3.21(604674133aff0acfeb79e087a907d188)
 
-  '@analogjs/vite-plugin-angular@2.3.1(@angular-devkit/build-angular@20.3.21(8c01346b7a36de487db43237896426cc))(@angular/build@20.3.21(df73556e4276f8bbdf3821d7292c36bb))(typescript@5.9.3)':
+  '@analogjs/vite-plugin-angular@2.3.1(@angular-devkit/build-angular@20.3.21(8c01346b7a36de487db43237896426cc))(@angular/build@20.3.21(df73556e4276f8bbdf3821d7292c36bb))(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.9.3))(typescript@5.9.3)':
     dependencies:
+      '@angular/compiler-cli': 20.3.18(@angular/compiler@20.3.18)(typescript@5.9.3)
       tinyglobby: 0.2.15
       ts-morph: 21.0.1
       typescript: 5.9.3
@@ -37072,13 +37104,13 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-angular@15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@5.5.3)(webpack-cli@5.1.4)':
+  '@angular-devkit/build-angular@15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@4.9.5)(webpack-cli@5.1.4)':
     dependencies:
       '@ampproject/remapping': 2.2.0
       '@angular-devkit/architect': 0.1502.10(chokidar@3.5.3)
       '@angular-devkit/build-webpack': 0.1502.10(chokidar@3.5.3)(webpack-dev-server@4.11.1(webpack-cli@5.1.4)(webpack@5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4)))(webpack@5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4))
       '@angular-devkit/core': 15.2.10(chokidar@3.5.3)
-      '@angular/compiler-cli': 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3)
+      '@angular/compiler-cli': 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5)
       '@babel/core': 7.20.12
       '@babel/generator': 7.20.14
       '@babel/helper-annotate-as-pure': 7.18.6
@@ -37090,7 +37122,7 @@ snapshots:
       '@babel/runtime': 7.20.13
       '@babel/template': 7.20.7
       '@discoveryjs/json-ext': 0.5.7
-      '@ngtools/webpack': 15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4))
+      '@ngtools/webpack': 15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(typescript@4.9.5)(webpack@5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4))
       ansi-colors: 4.1.3
       autoprefixer: 10.4.13(postcss@8.4.31)
       babel-loader: 9.1.2(@babel/core@7.20.12)(webpack@5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4))
@@ -37130,7 +37162,7 @@ snapshots:
       text-table: 0.2.0
       tree-kill: 1.2.2
       tslib: 2.5.0
-      typescript: 5.5.3
+      typescript: 4.9.5
       webpack: 5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.0.1(webpack@5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4))
       webpack-dev-server: 4.11.1(webpack-cli@5.1.4)(webpack@5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4))
@@ -37659,7 +37691,7 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3)':
+  '@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5)':
     dependencies:
       '@angular/compiler': 15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))
       '@babel/core': 7.19.3
@@ -37671,7 +37703,7 @@ snapshots:
       reflect-metadata: 0.1.14
       semver: 7.6.3
       tslib: 2.8.1
-      typescript: 5.5.3
+      typescript: 4.9.5
       yargs: 17.7.2
     transitivePeerDependencies:
       - supports-color
@@ -37940,10 +37972,10 @@ snapshots:
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 1.9.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -37960,10 +37992,10 @@ snapshots:
       '@babel/helpers': 7.28.6
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
       '@babel/types': 7.29.0
       convert-source-map: 1.9.0
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -38140,7 +38172,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.20.12)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -38192,7 +38224,7 @@ snapshots:
       '@babel/helper-optimise-call-expression': 7.27.1
       '@babel/helper-replace-supers': 7.28.6(@babel/core@7.20.12)
       '@babel/helper-skip-transparent-expression-wrappers': 7.27.1
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -38289,7 +38321,7 @@ snapshots:
       '@babel/core': 7.20.12
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
       semver: 6.3.1
@@ -38386,6 +38418,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-module-imports@7.27.1':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-module-imports@7.27.1(supports-color@5.5.0)':
     dependencies:
       '@babel/traverse': 7.29.0(supports-color@5.5.0)
@@ -38410,18 +38449,18 @@ snapshots:
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.19.3)':
     dependencies:
       '@babel/core': 7.19.3
-      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-module-transforms@7.28.6(@babel/core@7.20.12)':
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -38474,7 +38513,7 @@ snapshots:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.27.3
       '@babel/helper-wrap-function': 7.28.3
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -38519,7 +38558,7 @@ snapshots:
       '@babel/core': 7.20.12
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -38564,7 +38603,7 @@ snapshots:
       '@babel/core': 7.20.12
       '@babel/helper-member-expression-to-functions': 7.28.5
       '@babel/helper-optimise-call-expression': 7.27.1
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -39664,7 +39703,7 @@ snapshots:
   '@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.20.12)':
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.20.12)
     transitivePeerDependencies:
@@ -39700,7 +39739,7 @@ snapshots:
   '@babel/plugin-transform-async-to-generator@7.28.6(@babel/core@7.20.12)':
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-module-imports': 7.28.6(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-remap-async-to-generator': 7.27.1(@babel/core@7.20.12)
     transitivePeerDependencies:
@@ -39876,7 +39915,7 @@ snapshots:
       '@babel/helper-globals': 7.28.0
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-replace-supers': 7.27.1(@babel/core@7.20.12)
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -39980,7 +40019,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -40232,7 +40271,7 @@ snapshots:
       '@babel/core': 7.20.12
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -40491,7 +40530,7 @@ snapshots:
       '@babel/helper-module-transforms': 7.28.6(@babel/core@7.20.12)
       '@babel/helper-plugin-utils': 7.28.6
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.29.0(supports-color@5.5.0)
+      '@babel/traverse': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -41191,7 +41230,7 @@ snapshots:
   '@babel/plugin-transform-runtime@7.19.6(@babel/core@7.20.12)':
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
+      '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.28.6
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.20.12)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.20.12)
@@ -44476,7 +44515,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3))':
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -44490,7 +44529,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@20.16.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.16.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -45235,12 +45274,12 @@ snapshots:
       - supports-color
       - typescript
 
-  '@lerna/create@8.1.8(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.9.3)':
+  '@lerna/create@8.1.8(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.9.3)':
     dependencies:
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
-      '@nx/devkit': 17.3.2(nx@17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 17.3.2(nx@17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 19.0.11(encoding@0.1.13)
       aproba: 2.0.0
@@ -45279,7 +45318,7 @@ snapshots:
       npm-package-arg: 11.0.2
       npm-packlist: 8.0.2
       npm-registry-fetch: 17.1.0
-      nx: 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
+      nx: 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-queue: 6.6.2
@@ -49317,9 +49356,9 @@ snapshots:
 
   '@module-federation/bridge-shared@2.1.0': {}
 
-  '@module-federation/cli@2.0.1(typescript@4.9.5)':
+  '@module-federation/cli@2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))':
     dependencies:
-      '@module-federation/dts-plugin': 2.0.1(typescript@4.9.5)
+      '@module-federation/dts-plugin': 2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))
       '@module-federation/sdk': 2.0.1
       chalk: 3.0.0
       commander: 11.1.0
@@ -49332,9 +49371,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/cli@2.0.1(typescript@5.5.3)':
+  '@module-federation/cli@2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/sdk': 2.0.1
       chalk: 3.0.0
       commander: 11.1.0
@@ -49347,9 +49386,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/cli@2.0.1(typescript@5.6.2)':
+  '@module-federation/cli@2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))':
     dependencies:
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/sdk': 2.0.1
       chalk: 3.0.0
       commander: 11.1.0
@@ -49362,9 +49401,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/cli@2.0.1(typescript@5.9.3)':
+  '@module-federation/cli@2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/sdk': 2.0.1
       chalk: 3.0.0
       commander: 11.1.0
@@ -49377,9 +49416,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/cli@2.1.0(typescript@5.0.4)':
+  '@module-federation/cli@2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))':
     dependencies:
-      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)
+      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/sdk': 2.1.0
       chalk: 3.0.0
       commander: 11.1.0
@@ -49392,9 +49431,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/cli@2.5.1(node-fetch@3.3.2)(typescript@5.5.3)':
+  '@module-federation/cli@2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
       commander: 11.1.0
       jiti: 2.4.2
@@ -49405,9 +49444,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/cli@2.5.1(node-fetch@3.3.2)(typescript@5.9.3)':
+  '@module-federation/cli@2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
       commander: 11.1.0
       jiti: 2.4.2
@@ -49480,7 +49519,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@module-federation/dts-plugin@0.21.6(typescript@5.9.3)':
+  '@module-federation/dts-plugin@0.21.6(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/error-codes': 0.21.6
       '@module-federation/managers': 0.21.6
@@ -49499,13 +49538,15 @@ snapshots:
       rambda: 9.4.2
       typescript: 5.9.3
       ws: 8.18.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/dts-plugin@0.7.3(typescript@5.9.3)':
+  '@module-federation/dts-plugin@0.7.3(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/error-codes': 0.7.3
       '@module-federation/managers': 0.7.3
@@ -49524,13 +49565,15 @@ snapshots:
       rambda: 9.4.2
       typescript: 5.9.3
       ws: 8.18.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/dts-plugin@2.0.1(typescript@4.9.5)':
+  '@module-federation/dts-plugin@2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))':
     dependencies:
       '@module-federation/error-codes': 2.0.1
       '@module-federation/managers': 2.0.1
@@ -49549,13 +49592,15 @@ snapshots:
       rambda: 9.4.2
       typescript: 4.9.5
       ws: 8.18.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@4.9.5)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/dts-plugin@2.0.1(typescript@5.5.3)':
+  '@module-federation/dts-plugin@2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
       '@module-federation/error-codes': 2.0.1
       '@module-federation/managers': 2.0.1
@@ -49574,13 +49619,15 @@ snapshots:
       rambda: 9.4.2
       typescript: 5.5.3
       ws: 8.18.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.5.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/dts-plugin@2.0.1(typescript@5.6.2)':
+  '@module-federation/dts-plugin@2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))':
     dependencies:
       '@module-federation/error-codes': 2.0.1
       '@module-federation/managers': 2.0.1
@@ -49599,13 +49646,15 @@ snapshots:
       rambda: 9.4.2
       typescript: 5.6.2
       ws: 8.18.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.6.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/dts-plugin@2.0.1(typescript@5.9.3)':
+  '@module-federation/dts-plugin@2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/error-codes': 2.0.1
       '@module-federation/managers': 2.0.1
@@ -49624,13 +49673,15 @@ snapshots:
       rambda: 9.4.2
       typescript: 5.9.3
       ws: 8.18.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/dts-plugin@2.1.0(typescript@5.0.4)':
+  '@module-federation/dts-plugin@2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))':
     dependencies:
       '@module-federation/error-codes': 2.1.0
       '@module-federation/managers': 2.1.0
@@ -49648,13 +49699,15 @@ snapshots:
       rambda: 9.4.2
       typescript: 5.0.4
       ws: 8.18.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.0.4)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/dts-plugin@2.2.3(node-fetch@3.3.2)(typescript@5.9.3)':
+  '@module-federation/dts-plugin@2.2.3(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/error-codes': 2.2.3
       '@module-federation/managers': 2.2.3(node-fetch@3.3.2)
@@ -49672,6 +49725,8 @@ snapshots:
       rambda: 9.4.2
       typescript: 5.9.3
       ws: 8.18.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -49679,7 +49734,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/dts-plugin@2.5.1(node-fetch@3.3.2)(typescript@5.5.3)':
+  '@module-federation/dts-plugin@2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
       '@module-federation/error-codes': 2.5.1
       '@module-federation/managers': 2.5.1(node-fetch@3.3.2)
@@ -49692,12 +49747,14 @@ snapshots:
       typescript: 5.5.3
       undici: 7.24.7
       ws: 8.21.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.5.3)
     transitivePeerDependencies:
       - bufferutil
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/dts-plugin@2.5.1(node-fetch@3.3.2)(typescript@5.9.3)':
+  '@module-federation/dts-plugin@2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/error-codes': 2.5.1
       '@module-federation/managers': 2.5.1(node-fetch@3.3.2)
@@ -49710,25 +49767,28 @@ snapshots:
       typescript: 5.9.3
       undici: 7.24.7
       ws: 8.21.0
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@0.7.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.23.0))':
+  '@module-federation/enhanced@0.7.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.23.0))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.7.3
       '@module-federation/data-prefetch': 0.7.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@module-federation/dts-plugin': 0.7.3(typescript@5.9.3)
+      '@module-federation/dts-plugin': 0.7.3(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/managers': 0.7.3
-      '@module-federation/manifest': 0.7.3(typescript@5.9.3)
-      '@module-federation/rspack': 0.7.3(typescript@5.9.3)
+      '@module-federation/manifest': 0.7.3(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 0.7.3(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.7.3
       '@module-federation/sdk': 0.7.3
       btoa: 1.2.1
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.23.0)
     transitivePeerDependencies:
       - bufferutil
@@ -49738,17 +49798,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@0.4.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.3))(esbuild@0.17.19))':
+  '@module-federation/enhanced@2.0.1(@rspack/core@0.4.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.3))(esbuild@0.17.19))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@0.4.5)(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@0.4.5)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -49756,6 +49816,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.3))(esbuild@0.17.19)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -49766,17 +49827,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.5.3)
+      '@module-federation/cli': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -49784,6 +49845,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -49794,17 +49856,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -49812,6 +49874,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -49822,17 +49885,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.5.3)
+      '@module-federation/cli': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -49840,6 +49903,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -49850,17 +49914,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -49868,6 +49932,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -49878,17 +49943,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -49896,6 +49961,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(cssnano@6.0.1(postcss@8.4.47))(esbuild@0.17.19)(postcss@8.4.47)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -49906,17 +49972,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@4.9.5)
+      '@module-federation/cli': 2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@4.9.5)
+      '@module-federation/dts-plugin': 2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@4.9.5)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@4.9.5)
+      '@module-federation/manifest': 2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -49924,6 +49990,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 4.9.5
+      vue-tsc: 1.8.27(typescript@4.9.5)
       webpack: 5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(cssnano@6.0.1(postcss@8.4.47))(esbuild@0.17.19)(postcss@8.4.47)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -49934,17 +50001,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.5.3)
+      '@module-federation/cli': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -49952,6 +50019,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -49962,17 +50030,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -49980,6 +50048,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -49990,17 +50059,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50008,6 +50077,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(cssnano@6.0.1(postcss@8.4.47))(esbuild@0.17.19)(postcss@8.4.47)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50018,17 +50088,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.5.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.5.3)
+      '@module-federation/cli': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50036,6 +50106,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50046,17 +50117,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.6.2)
+      '@module-federation/cli': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/data-prefetch': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.6.2)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.6.2)
+      '@module-federation/manifest': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50064,6 +50135,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.6.2
+      vue-tsc: 1.8.27(typescript@5.6.2)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50074,17 +50146,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50092,6 +50164,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50102,17 +50175,46 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.0.1)(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
+      '@module-federation/data-prefetch': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
+      '@module-federation/error-codes': 2.0.1
+      '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
+      '@module-federation/managers': 2.0.1
+      '@module-federation/manifest': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.0.1)(@swc/helpers@0.5.18))(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
+      '@module-federation/runtime-tools': 2.0.1
+      '@module-federation/sdk': 2.0.1
+      btoa: 1.2.1
+      schema-utils: 4.3.3
+      upath: 2.0.1
+    optionalDependencies:
+      typescript: 5.6.2
+      vue-tsc: 1.8.27(typescript@5.6.2)
+      webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - supports-color
+      - utf-8-validate
+
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
+    dependencies:
+      '@module-federation/bridge-react-webpack-plugin': 2.0.1
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50120,6 +50222,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50130,17 +50233,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.5.3)
+      '@module-federation/cli': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50148,6 +50251,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50158,17 +50262,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.5.3)
+      '@module-federation/cli': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50176,6 +50280,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50186,17 +50291,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50204,6 +50309,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50214,17 +50320,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50232,6 +50338,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50242,17 +50349,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50260,6 +50367,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50270,17 +50378,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.5.3)
+      '@module-federation/cli': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50288,6 +50396,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.27.2)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50298,17 +50407,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.5.3)
+      '@module-federation/cli': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50316,6 +50425,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
       webpack: 5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(cssnano@6.0.1(postcss@8.4.47))(esbuild@0.17.19)(postcss@8.4.47)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50326,17 +50436,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50344,6 +50454,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50354,17 +50465,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50372,6 +50483,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50382,17 +50494,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50400,6 +50512,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(cssnano@6.0.1(postcss@8.4.47))(esbuild@0.17.19)(postcss@8.4.47)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50410,17 +50523,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/enhanced@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50428,6 +50541,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50438,17 +50552,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/enhanced@2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/data-prefetch': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.0.1
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
-      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -50456,6 +50570,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50466,17 +50581,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))':
+  '@module-federation/enhanced@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.1.0
-      '@module-federation/cli': 2.1.0(typescript@5.0.4)
+      '@module-federation/cli': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/data-prefetch': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)
+      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/error-codes': 2.1.0
       '@module-federation/inject-external-runtime-core-plugin': 2.1.0(@module-federation/runtime-tools@2.1.0)
       '@module-federation/managers': 2.1.0
-      '@module-federation/manifest': 2.1.0(typescript@5.0.4)
-      '@module-federation/rspack': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(typescript@5.0.4)
+      '@module-federation/manifest': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
+      '@module-federation/rspack': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/runtime-tools': 2.1.0
       '@module-federation/sdk': 2.1.0
       btoa: 1.2.1
@@ -50484,6 +50599,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.0.4
+      vue-tsc: 1.8.27(typescript@5.0.4)
       webpack: 5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50494,17 +50610,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
+  '@module-federation/enhanced@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.1.0
-      '@module-federation/cli': 2.1.0(typescript@5.0.4)
+      '@module-federation/cli': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/data-prefetch': 2.1.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
-      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)
+      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/error-codes': 2.1.0
       '@module-federation/inject-external-runtime-core-plugin': 2.1.0(@module-federation/runtime-tools@2.1.0)
       '@module-federation/managers': 2.1.0
-      '@module-federation/manifest': 2.1.0(typescript@5.0.4)
-      '@module-federation/rspack': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.0.4)
+      '@module-federation/manifest': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
+      '@module-federation/rspack': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/runtime-tools': 2.1.0
       '@module-federation/sdk': 2.1.0
       btoa: 1.2.1
@@ -50512,6 +50628,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.0.4
+      vue-tsc: 1.8.27(typescript@5.0.4)
       webpack: 5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50522,17 +50639,17 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))':
+  '@module-federation/enhanced@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.1.0
-      '@module-federation/cli': 2.1.0(typescript@5.0.4)
+      '@module-federation/cli': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/data-prefetch': 2.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)
+      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/error-codes': 2.1.0
       '@module-federation/inject-external-runtime-core-plugin': 2.1.0(@module-federation/runtime-tools@2.1.0)
       '@module-federation/managers': 2.1.0
-      '@module-federation/manifest': 2.1.0(typescript@5.0.4)
-      '@module-federation/rspack': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.0.4)
+      '@module-federation/manifest': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
+      '@module-federation/rspack': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/runtime-tools': 2.1.0
       '@module-federation/sdk': 2.1.0
       btoa: 1.2.1
@@ -50540,6 +50657,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.0.4
+      vue-tsc: 1.8.27(typescript@5.0.4)
       webpack: 5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50550,16 +50668,16 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(webpack@5.107.2)':
+  '@module-federation/enhanced@2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@3.3.2)
-      '@module-federation/cli': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)
+      '@module-federation/cli': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/error-codes': 2.5.1
       '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@module-federation/managers': 2.5.1(node-fetch@3.3.2)
-      '@module-federation/manifest': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)
-      '@module-federation/rspack': 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)
+      '@module-federation/manifest': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
+      '@module-federation/rspack': 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
       '@module-federation/webpack-bundler-runtime': 2.5.1(node-fetch@3.3.2)
@@ -50568,6 +50686,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
       webpack: 5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50575,16 +50694,16 @@ snapshots:
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/enhanced@2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(webpack@5.107.2)':
+  '@module-federation/enhanced@2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2)':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@3.3.2)
-      '@module-federation/cli': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)
+      '@module-federation/cli': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/error-codes': 2.5.1
       '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@module-federation/managers': 2.5.1(node-fetch@3.3.2)
-      '@module-federation/manifest': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)
-      '@module-federation/rspack': 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)
+      '@module-federation/manifest': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/rspack': 2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
       '@module-federation/webpack-bundler-runtime': 2.5.1(node-fetch@3.3.2)
@@ -50593,6 +50712,7 @@ snapshots:
       upath: 2.0.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
       webpack: 5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
@@ -50669,9 +50789,9 @@ snapshots:
     transitivePeerDependencies:
       - node-fetch
 
-  '@module-federation/manifest@0.7.3(typescript@5.9.3)':
+  '@module-federation/manifest@0.7.3(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
-      '@module-federation/dts-plugin': 0.7.3(typescript@5.9.3)
+      '@module-federation/dts-plugin': 0.7.3(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/managers': 0.7.3
       '@module-federation/sdk': 0.7.3
       chalk: 3.0.0
@@ -50684,9 +50804,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/manifest@2.0.1(typescript@4.9.5)':
+  '@module-federation/manifest@2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))':
     dependencies:
-      '@module-federation/dts-plugin': 2.0.1(typescript@4.9.5)
+      '@module-federation/dts-plugin': 2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))
       '@module-federation/managers': 2.0.1
       '@module-federation/sdk': 2.0.1
       chalk: 3.0.0
@@ -50699,9 +50819,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/manifest@2.0.1(typescript@5.5.3)':
+  '@module-federation/manifest@2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/managers': 2.0.1
       '@module-federation/sdk': 2.0.1
       chalk: 3.0.0
@@ -50714,9 +50834,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/manifest@2.0.1(typescript@5.6.2)':
+  '@module-federation/manifest@2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))':
     dependencies:
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/managers': 2.0.1
       '@module-federation/sdk': 2.0.1
       chalk: 3.0.0
@@ -50729,9 +50849,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/manifest@2.0.1(typescript@5.9.3)':
+  '@module-federation/manifest@2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/managers': 2.0.1
       '@module-federation/sdk': 2.0.1
       chalk: 3.0.0
@@ -50744,9 +50864,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/manifest@2.1.0(typescript@5.0.4)':
+  '@module-federation/manifest@2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))':
     dependencies:
-      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)
+      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/managers': 2.1.0
       '@module-federation/sdk': 2.1.0
       chalk: 3.0.0
@@ -50759,9 +50879,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/manifest@2.5.1(node-fetch@3.3.2)(typescript@5.5.3)':
+  '@module-federation/manifest@2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/managers': 2.5.1(node-fetch@3.3.2)
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
       find-pkg: 2.0.0
@@ -50772,9 +50892,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/manifest@2.5.1(node-fetch@3.3.2)(typescript@5.9.3)':
+  '@module-federation/manifest@2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/managers': 2.5.1(node-fetch@3.3.2)
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
       find-pkg: 2.0.0
@@ -50785,14 +50905,14 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/modern-js@2.1.0(@rsbuild/core@1.2.19)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))':
+  '@module-federation/modern-js@2.1.0(@rsbuild/core@1.2.19)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))':
     dependencies:
       '@modern-js/utils': 2.70.5
       '@module-federation/bridge-react': 2.1.0(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@module-federation/cli': 2.1.0(typescript@5.0.4)
-      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
-      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
-      '@module-federation/rsbuild-plugin': 2.1.0(@rsbuild/core@1.2.19)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
+      '@module-federation/cli': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
+      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
+      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
+      '@module-federation/rsbuild-plugin': 2.1.0(@rsbuild/core@1.2.19)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
       '@module-federation/runtime': 2.1.0
       '@module-federation/sdk': 2.1.0
       '@swc/helpers': 0.5.18
@@ -50807,6 +50927,7 @@ snapshots:
       react-router: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript: 5.0.4
+      vue-tsc: 1.8.27(typescript@5.0.4)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@rspack/core'
@@ -50816,14 +50937,14 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@module-federation/modern-js@2.1.0(@rsbuild/core@1.6.1)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react-router-dom@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-router@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
+  '@module-federation/modern-js@2.1.0(@rsbuild/core@1.6.1)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react-router-dom@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-router@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
     dependencies:
       '@modern-js/utils': 2.70.5
       '@module-federation/bridge-react': 2.1.0(react-dom@17.0.2(react@17.0.2))(react-router-dom@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react-router@7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2))(react@17.0.2)
-      '@module-federation/cli': 2.1.0(typescript@5.0.4)
-      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
-      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
-      '@module-federation/rsbuild-plugin': 2.1.0(@rsbuild/core@1.6.1)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/cli': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
+      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/rsbuild-plugin': 2.1.0(@rsbuild/core@1.6.1)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
       '@module-federation/runtime': 2.1.0
       '@module-federation/sdk': 2.1.0
       '@swc/helpers': 0.5.18
@@ -50838,6 +50959,7 @@ snapshots:
       react-router: 7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       react-router-dom: 7.13.0(react-dom@17.0.2(react@17.0.2))(react@17.0.2)
       typescript: 5.0.4
+      vue-tsc: 1.8.27(typescript@5.0.4)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@rspack/core'
@@ -50847,14 +50969,14 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@module-federation/modern-js@2.1.0(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))':
+  '@module-federation/modern-js@2.1.0(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))':
     dependencies:
       '@modern-js/utils': 2.70.5
       '@module-federation/bridge-react': 2.1.0(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@module-federation/cli': 2.1.0(typescript@5.0.4)
-      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
-      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
-      '@module-federation/rsbuild-plugin': 2.1.0(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
+      '@module-federation/cli': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
+      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
+      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
+      '@module-federation/rsbuild-plugin': 2.1.0(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
       '@module-federation/runtime': 2.1.0
       '@module-federation/sdk': 2.1.0
       '@swc/helpers': 0.5.18
@@ -50869,6 +50991,7 @@ snapshots:
       react-router: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript: 5.0.4
+      vue-tsc: 1.8.27(typescript@5.0.4)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@rspack/core'
@@ -50878,14 +51001,14 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@module-federation/modern-js@2.70.6(@rsbuild/core@1.6.15)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
+  '@module-federation/modern-js@2.70.6(@rsbuild/core@1.6.15)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
     dependencies:
       '@modern-js/utils': 2.70.5
       '@module-federation/bridge-react': 2.0.1(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
-      '@module-federation/node': 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
-      '@module-federation/rsbuild-plugin': 2.0.1(@rsbuild/core@1.6.15)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/node': 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/rsbuild-plugin': 2.0.1(@rsbuild/core@1.6.15)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@swc/helpers': 0.5.18
@@ -50900,6 +51023,7 @@ snapshots:
       react-router: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@rspack/core'
@@ -50909,14 +51033,14 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@module-federation/modern-js@2.70.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/modern-js@2.70.6(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@modern-js/utils': 2.70.5
       '@module-federation/bridge-react': 2.0.1(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@module-federation/cli': 2.0.1(typescript@4.9.5)
-      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/node': 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/rsbuild-plugin': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/cli': 2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/node': 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/rsbuild-plugin': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@swc/helpers': 0.5.18
@@ -50931,6 +51055,7 @@ snapshots:
       react-router: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript: 4.9.5
+      vue-tsc: 1.8.27(typescript@4.9.5)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@rspack/core'
@@ -50940,14 +51065,14 @@ snapshots:
       - utf-8-validate
       - webpack
 
-  '@module-federation/modern-js@2.70.6(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/modern-js@2.70.6(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@modern-js/utils': 2.70.5
       '@module-federation/bridge-react': 2.0.1(react-dom@18.3.1(react@18.3.1))(react-router-dom@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-router@7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
-      '@module-federation/cli': 2.0.1(typescript@5.9.3)
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/node': 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/rsbuild-plugin': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/cli': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/node': 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/rsbuild-plugin': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@swc/helpers': 0.5.18
@@ -50962,6 +51087,7 @@ snapshots:
       react-router: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 7.13.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - '@rsbuild/core'
       - '@rspack/core'
@@ -51009,7 +51135,7 @@ snapshots:
       - typescript
       - yaml
 
-  '@module-federation/native-federation-typescript@0.6.0(typescript@5.5.3)':
+  '@module-federation/native-federation-typescript@0.6.0(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
       adm-zip: 0.5.16
       ansi-colors: 4.1.3
@@ -51017,13 +51143,15 @@ snapshots:
       rambda: 9.4.2
       typescript: 5.5.3
       unplugin: 1.16.1
+    optionalDependencies:
+      vue-tsc: 1.8.27(typescript@5.5.3)
     transitivePeerDependencies:
       - debug
 
-  '@module-federation/nextjs-mf@8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/nextjs-mf@8.8.56(@rspack/core@1.7.6(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/node': 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/node': 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@module-federation/webpack-bundler-runtime': 2.0.1
@@ -51043,10 +51171,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/nextjs-mf@8.8.56(next@12.3.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/nextjs-mf@8.8.56(next@12.3.4(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/node': 2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/node': 2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@module-federation/webpack-bundler-runtime': 2.0.1
@@ -51066,10 +51194,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/nextjs-mf@8.8.56(next@14.2.13(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.24.7)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/nextjs-mf@8.8.56(next@14.2.13(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.24.7)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/node': 2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/node': 2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@module-federation/webpack-bundler-runtime': 2.0.1
@@ -51089,10 +51217,10 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/nextjs-mf@8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/nextjs-mf@8.8.56(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-jsx@5.1.6(@babel/core@7.29.0)(babel-plugin-macros@3.1.0)(react@18.3.1))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/node': 2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/node': 2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@module-federation/webpack-bundler-runtime': 2.0.1
@@ -51112,9 +51240,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51133,9 +51261,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51154,9 +51282,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51175,9 +51303,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(webpack@5.105.3)':
+  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(webpack@5.105.3)
+      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51196,9 +51324,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/node@2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(webpack@5.105.3)
+      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51217,9 +51345,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.0.1)(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.0.1)(@swc/helpers@0.5.18))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))(webpack@5.105.3)
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51238,9 +51366,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51259,9 +51387,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3)
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51280,9 +51408,30 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
+  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
+      '@module-federation/runtime': 2.0.1
+      '@module-federation/sdk': 2.0.1
+      btoa: 1.2.1
+      encoding: 0.1.13
+      node-fetch: 2.7.0(encoding@0.1.13)
+    optionalDependencies:
+      webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
+    transitivePeerDependencies:
+      - '@rspack/core'
+      - bufferutil
+      - debug
+      - react
+      - react-dom
+      - supports-color
+      - typescript
+      - utf-8-validate
+      - vue-tsc
+
+  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
+    dependencies:
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51301,9 +51450,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/node@2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51322,9 +51471,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)':
+  '@module-federation/node@2.7.32(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(webpack@5.105.3)
+      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3)
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51343,9 +51492,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/node@2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51364,9 +51513,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/node@2.7.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/runtime': 2.0.1
       '@module-federation/sdk': 2.0.1
       btoa: 1.2.1
@@ -51385,9 +51534,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))':
+  '@module-federation/node@2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))':
     dependencies:
-      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
+      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
       '@module-federation/runtime': 2.1.0
       '@module-federation/sdk': 2.1.0
       btoa: 1.2.1
@@ -51406,9 +51555,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
+  '@module-federation/node@2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
     dependencies:
-      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
       '@module-federation/runtime': 2.1.0
       '@module-federation/sdk': 2.1.0
       btoa: 1.2.1
@@ -51427,9 +51576,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))':
+  '@module-federation/node@2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))':
     dependencies:
-      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
+      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
       '@module-federation/runtime': 2.1.0
       '@module-federation/sdk': 2.1.0
       btoa: 1.2.1
@@ -51452,10 +51601,10 @@ snapshots:
     dependencies:
       '@module-federation/sdk': 0.17.1
 
-  '@module-federation/rsbuild-plugin@2.0.1(@rsbuild/core@1.6.15)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
+  '@module-federation/rsbuild-plugin@2.0.1(@rsbuild/core@1.6.15)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
-      '@module-federation/node': 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/node': 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
       '@module-federation/sdk': 2.0.1
       fs-extra: 11.3.0
     optionalDependencies:
@@ -51472,10 +51621,10 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/rsbuild-plugin@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/node': 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/node': 2.7.32(@rspack/core@1.7.6(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/sdk': 2.0.1
       fs-extra: 11.3.0
     transitivePeerDependencies:
@@ -51490,10 +51639,10 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@module-federation/rsbuild-plugin@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@module-federation/node': 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/enhanced': 2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@module-federation/node': 2.7.32(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/sdk': 2.0.1
       fs-extra: 11.3.0
     transitivePeerDependencies:
@@ -51508,10 +51657,10 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.1.0(@rsbuild/core@1.2.19)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))':
+  '@module-federation/rsbuild-plugin@2.1.0(@rsbuild/core@1.2.19)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))':
     dependencies:
-      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
-      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
+      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
+      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.10.18(@swc/helpers@0.5.13))(cssnano@6.1.2(postcss@8.4.47))(esbuild@0.17.19)(html-minifier-terser@7.2.0)(postcss@8.4.47))
       '@module-federation/sdk': 2.1.0
       fs-extra: 11.3.0
     optionalDependencies:
@@ -51528,10 +51677,10 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.1.0(@rsbuild/core@1.6.1)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
+  '@module-federation/rsbuild-plugin@2.1.0(@rsbuild/core@1.6.1)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))':
     dependencies:
-      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
-      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
+      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.14.0(@swc/helpers@0.5.18))(cssnano@6.1.2(postcss@8.5.6))(esbuild@0.25.5)(html-minifier-terser@7.2.0)(postcss@8.5.6))
       '@module-federation/sdk': 2.1.0
       fs-extra: 11.3.0
     optionalDependencies:
@@ -51548,10 +51697,10 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rsbuild-plugin@2.1.0(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))':
+  '@module-federation/rsbuild-plugin@2.1.0(@rsbuild/core@1.7.3)(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))':
     dependencies:
-      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
-      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
+      '@module-federation/enhanced': 2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
+      '@module-federation/node': 2.7.33(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(postcss@8.5.6))
       '@module-federation/sdk': 2.1.0
       fs-extra: 11.3.0
     optionalDependencies:
@@ -51568,241 +51717,274 @@ snapshots:
       - vue-tsc
       - webpack
 
-  '@module-federation/rspack@0.7.3(typescript@5.9.3)':
+  '@module-federation/rspack@0.7.3(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 0.7.3
-      '@module-federation/dts-plugin': 0.7.3(typescript@5.9.3)
+      '@module-federation/dts-plugin': 0.7.3(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/managers': 0.7.3
-      '@module-federation/manifest': 0.7.3(typescript@5.9.3)
+      '@module-federation/manifest': 0.7.3(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 0.7.3
       '@module-federation/sdk': 0.7.3
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.0.1(@rspack/core@0.4.5)(typescript@5.9.3)':
+  '@module-federation/rspack@2.0.1(@rspack/core@0.4.5)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@rspack/core': 0.4.5
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@4.9.5)':
+  '@module-federation/rspack@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/dts-plugin': 2.0.1(typescript@4.9.5)
+      '@module-federation/dts-plugin': 2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@4.9.5)
+      '@module-federation/manifest': 2.0.1(typescript@4.9.5)(vue-tsc@1.8.27(typescript@4.9.5))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@rspack/core': 1.7.6(@swc/helpers@0.5.18)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 4.9.5
+      vue-tsc: 1.8.27(typescript@4.9.5)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)':
+  '@module-federation/rspack@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@rspack/core': 1.7.6(@swc/helpers@0.5.18)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.6.2)':
+  '@module-federation/rspack@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.6.2)
+      '@module-federation/manifest': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@rspack/core': 1.7.6(@swc/helpers@0.5.18)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.6.2
+      vue-tsc: 1.8.27(typescript@5.6.2)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)':
+  '@module-federation/rspack@2.0.1(@rspack/core@1.7.6(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@rspack/core': 1.7.6(@swc/helpers@0.5.18)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(typescript@5.9.3)':
+  '@module-federation/rspack@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.0.1)(@swc/helpers@0.5.18))(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.6.2)(vue-tsc@1.8.27(typescript@5.6.2))
+      '@module-federation/runtime-tools': 2.0.1
+      '@module-federation/sdk': 2.0.1
+      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.0.1)(@swc/helpers@0.5.18)
+      btoa: 1.2.1
+    optionalDependencies:
+      typescript: 5.6.2
+      vue-tsc: 1.8.27(typescript@5.6.2)
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@module-federation/rspack@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
+    dependencies:
+      '@module-federation/bridge-react-webpack-plugin': 2.0.1
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
+      '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
+      '@module-federation/managers': 2.0.1
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@2.7.0(encoding@0.1.13)))(@swc/helpers@0.5.18)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)':
+  '@module-federation/rspack@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.5.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)':
+  '@module-federation/rspack@2.0.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.0.1
-      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/inject-external-runtime-core-plugin': 2.0.1(@module-federation/runtime-tools@2.0.1)
       '@module-federation/managers': 2.0.1
-      '@module-federation/manifest': 2.0.1(typescript@5.9.3)
+      '@module-federation/manifest': 2.0.1(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.0.1
       '@module-federation/sdk': 2.0.1
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(typescript@5.0.4)':
+  '@module-federation/rspack@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13))(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.1.0
-      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)
+      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/inject-external-runtime-core-plugin': 2.1.0(@module-federation/runtime-tools@2.1.0)
       '@module-federation/managers': 2.1.0
-      '@module-federation/manifest': 2.1.0(typescript@5.0.4)
+      '@module-federation/manifest': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/runtime-tools': 2.1.0
       '@module-federation/sdk': 2.1.0
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.0.4
+      vue-tsc: 1.8.27(typescript@5.0.4)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.0.4)':
+  '@module-federation/rspack@2.1.0(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.1.0
-      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)
+      '@module-federation/dts-plugin': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/inject-external-runtime-core-plugin': 2.1.0(@module-federation/runtime-tools@2.1.0)
       '@module-federation/managers': 2.1.0
-      '@module-federation/manifest': 2.1.0(typescript@5.0.4)
+      '@module-federation/manifest': 2.1.0(typescript@5.0.4)(vue-tsc@1.8.27(typescript@5.0.4))
       '@module-federation/runtime-tools': 2.1.0
       '@module-federation/sdk': 2.1.0
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18)
       btoa: 1.2.1
     optionalDependencies:
       typescript: 5.0.4
+      vue-tsc: 1.8.27(typescript@5.0.4)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
       - utf-8-validate
 
-  '@module-federation/rspack@2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)':
+  '@module-federation/rspack@2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@3.3.2)
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@module-federation/managers': 2.5.1(node-fetch@3.3.2)
-      '@module-federation/manifest': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)
+      '@module-federation/manifest': 2.5.1(node-fetch@3.3.2)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))
       '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18)
     optionalDependencies:
       typescript: 5.5.3
+      vue-tsc: 1.8.27(typescript@5.5.3)
     transitivePeerDependencies:
       - bufferutil
       - node-fetch
       - utf-8-validate
 
-  '@module-federation/rspack@2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)':
+  '@module-federation/rspack@2.5.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
       '@module-federation/bridge-react-webpack-plugin': 2.5.1(node-fetch@3.3.2)
-      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/inject-external-runtime-core-plugin': 2.5.1(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))
       '@module-federation/managers': 2.5.1(node-fetch@3.3.2)
-      '@module-federation/manifest': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)
+      '@module-federation/manifest': 2.5.1(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime-tools': 2.5.1(node-fetch@3.3.2)
       '@module-federation/sdk': 2.5.1(node-fetch@3.3.2)
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18)
     optionalDependencies:
       typescript: 5.9.3
+      vue-tsc: 1.8.27(typescript@5.9.3)
     transitivePeerDependencies:
       - bufferutil
       - node-fetch
@@ -52047,9 +52229,9 @@ snapshots:
     optionalDependencies:
       node-fetch: 3.3.2
 
-  '@module-federation/storybook-addon@3.0.6(dd35e7cd74fcdb2069ae983379e76c3b)':
+  '@module-federation/storybook-addon@3.0.6(fd2068114f0df00188ff3db796f5fd0a)':
     dependencies:
-      '@module-federation/enhanced': 0.7.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.23.0))
+      '@module-federation/enhanced': 0.7.3(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.23.0))
       '@module-federation/sdk': 0.7.3
       '@module-federation/utilities': 3.1.26(react-dom@17.0.2(react@17.0.2))(react@17.0.2)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.23.0))
       '@nx/react': 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@25.1.0)(js-yaml@4.1.0)(nx@17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.3)(webpack@5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.23.0))
@@ -52103,7 +52285,7 @@ snapshots:
       find-pkg: 2.0.0
       resolve: 1.22.8
 
-  '@module-federation/typescript@3.1.3(encoding@0.1.13)(next@16.1.6(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(webpack@5.105.3)':
+  '@module-federation/typescript@3.1.3(encoding@0.1.13)(next@16.1.6(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.3)(vue-tsc@1.8.27(typescript@5.5.3))(webpack@5.105.3)':
     dependencies:
       lodash.get: 4.4.2
       node-fetch: 2.7.0(encoding@0.1.13)
@@ -52113,6 +52295,7 @@ snapshots:
       next: 16.1.6(@babel/core@7.24.7)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+      vue-tsc: 1.8.27(typescript@5.5.3)
     transitivePeerDependencies:
       - encoding
 
@@ -52132,9 +52315,9 @@ snapshots:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  '@module-federation/vite@1.11.0(rollup@4.59.0)(typescript@5.9.3)(vite@5.3.3(@types/node@25.1.0)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0))':
+  '@module-federation/vite@1.11.0(rollup@4.59.0)(typescript@5.9.3)(vite@5.3.3(@types/node@25.1.0)(less@4.5.1)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0))(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
-      '@module-federation/dts-plugin': 0.21.6(typescript@5.9.3)
+      '@module-federation/dts-plugin': 0.21.6(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime': 0.21.6
       '@module-federation/sdk': 0.21.6
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -52152,9 +52335,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/vite@1.13.5(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(less@4.4.0)(sass-embedded@1.97.3)(sass@1.90.0)(stylus@0.62.0)(terser@5.46.0)(yaml@2.8.2))':
+  '@module-federation/vite@1.13.5(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(less@4.4.0)(sass-embedded@1.97.3)(sass@1.90.0)(stylus@0.62.0)(terser@5.46.0)(yaml@2.8.2))(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.2.3(node-fetch@3.3.2)(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.2.3(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime': 2.2.3(node-fetch@3.3.2)
       '@module-federation/sdk': 2.2.3(node-fetch@3.3.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -52174,9 +52357,9 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/vite@1.13.5(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0)(yaml@2.8.2))':
+  '@module-federation/vite@1.13.5(node-fetch@3.3.2)(rollup@4.59.0)(typescript@5.9.3)(vite@7.3.1(@types/node@25.1.0)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.46.0)(yaml@2.8.2))(vue-tsc@1.8.27(typescript@5.9.3))':
     dependencies:
-      '@module-federation/dts-plugin': 2.2.3(node-fetch@3.3.2)(typescript@5.9.3)
+      '@module-federation/dts-plugin': 2.2.3(node-fetch@3.3.2)(typescript@5.9.3)(vue-tsc@1.8.27(typescript@5.9.3))
       '@module-federation/runtime': 2.2.3(node-fetch@3.3.2)
       '@module-federation/sdk': 2.2.3(node-fetch@3.3.2)
       '@rollup/pluginutils': 5.3.0(rollup@4.59.0)
@@ -52662,16 +52845,16 @@ snapshots:
   '@next/swc-win32-x64-msvc@16.1.6':
     optional: true
 
-  '@ngtools/webpack@15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4))':
+  '@ngtools/webpack@15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(typescript@4.9.5)(webpack@5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4))':
     dependencies:
-      '@angular/compiler-cli': 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3)
-      typescript: 5.5.3
+      '@angular/compiler-cli': 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5)
+      typescript: 4.9.5
       webpack: 5.76.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.17.8)(webpack-cli@5.1.4)
 
-  '@ngtools/webpack@15.2.11(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(typescript@5.5.3)(webpack@5.105.3)':
+  '@ngtools/webpack@15.2.11(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(typescript@4.9.5)(webpack@5.105.3)':
     dependencies:
-      '@angular/compiler-cli': 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3)
-      typescript: 5.5.3
+      '@angular/compiler-cli': 15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5)
+      typescript: 4.9.5
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
 
   '@ngtools/webpack@20.3.21(@angular/compiler-cli@20.3.18(@angular/compiler@20.3.18)(typescript@5.9.3))(typescript@5.9.3)(webpack@5.105.0(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.9)(postcss@8.5.6))':
@@ -52680,15 +52863,15 @@ snapshots:
       typescript: 5.9.3
       webpack: 5.105.0(@swc/core@1.15.8(@swc/helpers@0.5.18))(esbuild@0.25.9)(postcss@8.5.6)
 
-  '@nguniversal/builders@16.2.0(@angular-devkit/build-angular@15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@5.5.3)(webpack-cli@5.1.4))(@angular/common@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))(@types/express@4.17.25)(chokidar@3.6.0)(typescript@5.5.3)':
+  '@nguniversal/builders@16.2.0(@angular-devkit/build-angular@15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@4.9.5)(webpack-cli@5.1.4))(@angular/common@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))(@types/express@4.17.25)(chokidar@3.6.0)(typescript@4.9.5)':
     dependencies:
       '@angular-devkit/architect': 0.1602.16(chokidar@3.6.0)
-      '@angular-devkit/build-angular': 15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@5.5.3))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@5.5.3)(webpack-cli@5.1.4)
+      '@angular-devkit/build-angular': 15.2.10(@angular/compiler-cli@15.2.10(@angular/compiler@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10)))(typescript@4.9.5))(@angular/platform-server@15.2.10(6676711f88f9c40c18b0e2629d70e5ad))(@swc/core@1.15.8(@swc/helpers@0.5.18))(html-webpack-plugin@5.6.0(@rspack/core@1.7.6(@swc/helpers@0.5.18))(webpack@5.105.3))(sass-embedded@1.97.3)(tailwindcss@3.4.19(yaml@2.8.2))(typescript@4.9.5)(webpack-cli@5.1.4)
       '@angular-devkit/core': 16.2.16(chokidar@3.6.0)
       '@nguniversal/common': 16.2.0(@angular/common@15.2.10(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))(rxjs@7.8.2))(@angular/core@15.2.10(rxjs@7.8.2)(zone.js@0.14.10))
       browser-sync: 2.29.3
       express: 4.22.1
-      guess-parser: 0.4.22(typescript@5.5.3)
+      guess-parser: 0.4.22(typescript@4.9.5)
       http-proxy-middleware: 2.0.9(@types/express@4.17.25)
       ora: 5.4.1
       piscina: 4.0.0
@@ -53416,9 +53599,9 @@ snapshots:
       - verdaccio
       - webpack
 
-  '@nrwl/tao@17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))':
+  '@nrwl/tao@17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))':
     dependencies:
-      nx: 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
+      nx: 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
       tslib: 2.8.1
     transitivePeerDependencies:
       - '@swc-node/register'
@@ -56860,8 +57043,8 @@ snapshots:
       '@babel/code-frame': 7.24.2
       '@rsdoctor/types': 0.3.7(@rspack/core@2.0.8(@module-federation/runtime-tools@2.5.1(node-fetch@3.3.2))(@swc/helpers@0.5.18))(@swc/core@1.15.8(@swc/helpers@0.5.18))
       '@types/estree': 1.0.0
-      acorn: 8.15.0
-      acorn-import-assertions: 1.9.0(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-import-assertions: 1.9.0(acorn@8.16.0)
       acorn-walk: 8.3.2
       chalk: 4.1.2
       connect: 3.7.0
@@ -57468,6 +57651,13 @@ snapshots:
     optionalDependencies:
       '@swc/helpers': 0.5.18
 
+  '@rspack/core@2.0.8(@module-federation/runtime-tools@2.0.1)(@swc/helpers@0.5.18)':
+    dependencies:
+      '@rspack/binding': 2.0.8
+    optionalDependencies:
+      '@module-federation/runtime-tools': 2.0.1
+      '@swc/helpers': 0.5.18
+
   '@rspack/core@2.0.8(@module-federation/runtime-tools@2.1.0)(@swc/helpers@0.5.13)':
     dependencies:
       '@rspack/binding': 2.0.8
@@ -57497,7 +57687,7 @@ snapshots:
     dependencies:
       '@rspack/core': 1.7.6(@swc/helpers@0.5.18)
       chokidar: 3.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       p-retry: 6.2.1
       webpack-dev-server: 5.2.2(webpack-cli@5.1.4)(webpack@5.105.3)
       ws: 8.21.0
@@ -58530,7 +58720,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.15.8(@swc/helpers@0.5.18)
       colorette: 2.0.20
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       oxc-resolver: 1.12.0
       pirates: 4.0.7
       tslib: 2.8.1
@@ -58546,7 +58736,7 @@ snapshots:
       '@swc-node/sourcemap-support': 0.5.1
       '@swc/core': 1.15.8(@swc/helpers@0.5.18)
       colorette: 2.0.20
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       oxc-resolver: 1.12.0
       pirates: 4.0.7
       tslib: 2.8.1
@@ -60233,6 +60423,22 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  '@volar/language-core@1.11.1':
+    dependencies:
+      '@volar/source-map': 1.11.1
+    optional: true
+
+  '@volar/source-map@1.11.1':
+    dependencies:
+      muggle-string: 0.3.1
+    optional: true
+
+  '@volar/typescript@1.11.1':
+    dependencies:
+      '@volar/language-core': 1.11.1
+      path-browserify: 1.0.1
+    optional: true
+
   '@vue/babel-helper-vue-jsx-merge-props@1.4.0': {}
 
   '@vue/babel-helper-vue-transform-on@1.5.0': {}
@@ -61077,6 +61283,81 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vue/language-core@1.8.27(typescript@4.9.5)':
+    dependencies:
+      '@volar/language-core': 1.11.1
+      '@volar/source-map': 1.11.1
+      '@vue/compiler-dom': 3.5.27
+      '@vue/shared': 3.5.27
+      computeds: 0.0.1
+      minimatch: 9.0.5
+      muggle-string: 0.3.1
+      path-browserify: 1.0.1
+      vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 4.9.5
+    optional: true
+
+  '@vue/language-core@1.8.27(typescript@5.0.4)':
+    dependencies:
+      '@volar/language-core': 1.11.1
+      '@volar/source-map': 1.11.1
+      '@vue/compiler-dom': 3.5.27
+      '@vue/shared': 3.5.27
+      computeds: 0.0.1
+      minimatch: 9.0.5
+      muggle-string: 0.3.1
+      path-browserify: 1.0.1
+      vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.0.4
+    optional: true
+
+  '@vue/language-core@1.8.27(typescript@5.5.3)':
+    dependencies:
+      '@volar/language-core': 1.11.1
+      '@volar/source-map': 1.11.1
+      '@vue/compiler-dom': 3.5.27
+      '@vue/shared': 3.5.27
+      computeds: 0.0.1
+      minimatch: 9.0.5
+      muggle-string: 0.3.1
+      path-browserify: 1.0.1
+      vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.5.3
+    optional: true
+
+  '@vue/language-core@1.8.27(typescript@5.6.2)':
+    dependencies:
+      '@volar/language-core': 1.11.1
+      '@volar/source-map': 1.11.1
+      '@vue/compiler-dom': 3.5.27
+      '@vue/shared': 3.5.27
+      computeds: 0.0.1
+      minimatch: 9.0.5
+      muggle-string: 0.3.1
+      path-browserify: 1.0.1
+      vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.6.2
+    optional: true
+
+  '@vue/language-core@1.8.27(typescript@5.9.3)':
+    dependencies:
+      '@volar/language-core': 1.11.1
+      '@volar/source-map': 1.11.1
+      '@vue/compiler-dom': 3.5.27
+      '@vue/shared': 3.5.27
+      computeds: 0.0.1
+      minimatch: 9.0.5
+      muggle-string: 0.3.1
+      path-browserify: 1.0.1
+      vue-template-compiler: 2.7.16
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
   '@vue/reactivity@3.4.31':
     dependencies:
       '@vue/shared': 3.4.31
@@ -61329,7 +61610,7 @@ snapshots:
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.3)':
     dependencies:
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.105.3)
+      webpack-cli: 5.1.4(webpack-dev-server@4.11.1)(webpack@5.105.3)
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.107.2)':
     dependencies:
@@ -61339,7 +61620,7 @@ snapshots:
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.3)':
     dependencies:
       webpack: 5.105.3(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.105.3)
+      webpack-cli: 5.1.4(webpack-dev-server@4.11.1)(webpack@5.105.3)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.107.2)':
     dependencies:
@@ -61391,13 +61672,13 @@ snapshots:
       webpack: 5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.107.2)
 
-  '@wessberg/ts-evaluator@0.0.27(typescript@5.5.3)':
+  '@wessberg/ts-evaluator@0.0.27(typescript@4.9.5)':
     dependencies:
       chalk: 4.1.2
       jsdom: 16.7.0
       object-path: 0.11.8
       tslib: 2.8.1
-      typescript: 5.5.3
+      typescript: 4.9.5
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -61470,10 +61751,6 @@ snapshots:
       acorn: 8.16.0
       acorn-walk: 8.3.4
 
-  acorn-import-assertions@1.9.0(acorn@8.15.0):
-    dependencies:
-      acorn: 8.15.0
-
   acorn-import-assertions@1.9.0(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -61485,10 +61762,6 @@ snapshots:
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
-
-  acorn-jsx@5.3.2(acorn@8.15.0):
-    dependencies:
-      acorn: 8.15.0
 
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
@@ -62055,7 +62328,7 @@ snapshots:
 
   axios@1.13.2:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.2)
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -62081,7 +62354,7 @@ snapshots:
 
   axios@1.5.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.2)
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -62089,7 +62362,7 @@ snapshots:
 
   axios@1.7.2:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.2)
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -62097,7 +62370,7 @@ snapshots:
 
   axios@1.7.7:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.2)
+      follow-redirects: 1.15.11(debug@4.4.3)
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -63033,7 +63306,7 @@ snapshots:
       etag: 1.8.1
       fresh: 0.5.2
       fs-extra: 3.0.1
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3)
       immutable: 3.8.2
       localtunnel: 2.0.2
       micromatch: 4.0.8
@@ -63391,7 +63664,7 @@ snapshots:
 
   centra@2.7.0:
     dependencies:
-      follow-redirects: 1.15.11(debug@4.3.2)
+      follow-redirects: 1.15.11(debug@4.4.3)
     transitivePeerDependencies:
       - debug
 
@@ -63698,7 +63971,7 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
       '@types/estree': 1.0.8
-      acorn: 8.15.0
+      acorn: 8.16.0
       estree-walker: 3.0.3
       periscopic: 3.1.0
 
@@ -63829,6 +64102,9 @@ snapshots:
       - supports-color
 
   compute-scroll-into-view@3.1.1: {}
+
+  computeds@0.0.1:
+    optional: true
 
   concat-map@0.0.1: {}
 
@@ -64312,13 +64588,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3)):
+  create-jest@29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -67285,14 +67561,14 @@ snapshots:
 
   espree@10.4.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 4.2.1
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 3.4.3
 
   esprima@1.2.2: {}
@@ -68647,10 +68923,10 @@ snapshots:
 
   graphql@16.12.0: {}
 
-  guess-parser@0.4.22(typescript@5.5.3):
+  guess-parser@0.4.22(typescript@4.9.5):
     dependencies:
-      '@wessberg/ts-evaluator': 0.0.27(typescript@5.5.3)
-      typescript: 5.5.3
+      '@wessberg/ts-evaluator': 0.0.27(typescript@4.9.5)
+      typescript: 4.9.5
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -69249,7 +69525,7 @@ snapshots:
     dependencies:
       '@tootallnate/once': 1.1.2
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -69295,7 +69571,7 @@ snapshots:
   http-proxy-middleware@2.0.9(@types/express@4.17.25):
     dependencies:
       '@types/http-proxy': 1.17.17
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -69315,14 +69591,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  http-proxy@1.18.1:
-    dependencies:
-      eventemitter3: 4.0.7
-      follow-redirects: 1.15.11(debug@4.4.3)
-      requires-port: 1.0.0
-    transitivePeerDependencies:
-      - debug
-
   http-proxy@1.18.1(debug@4.4.3):
     dependencies:
       eventemitter3: 4.0.7
@@ -69337,7 +69605,7 @@ snapshots:
       colors: 1.4.0
       corser: 2.0.1
       he: 1.2.0
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3)
       mime: 1.6.0
       minimist: 1.2.8
       opener: 1.5.2
@@ -69356,7 +69624,7 @@ snapshots:
       corser: 2.0.1
       he: 1.2.0
       html-encoding-sniffer: 3.0.0
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3)
       mime: 1.6.0
       minimist: 1.2.8
       opener: 1.5.2
@@ -70119,16 +70387,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3)):
+  jest-cli@29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3))
+      create-jest: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3))
+      jest-config: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -70285,7 +70553,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.16.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3)):
+  jest-config@29.7.0(@types/node@20.16.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -70311,7 +70579,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.16.5
-      ts-node: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3)
+      ts-node: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -70379,7 +70647,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3)):
+  jest-config@29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -70405,7 +70673,7 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 20.9.0
-      ts-node: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3)
+      ts-node: 10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -71027,12 +71295,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3)):
+  jest@29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3))
+      jest-cli: 29.7.0(@types/node@20.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -71330,7 +71598,7 @@ snapshots:
 
   jsonc-eslint-parser@2.4.2:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       eslint-visitor-keys: 3.4.3
       espree: 9.6.1
       semver: 7.6.3
@@ -71684,13 +71952,13 @@ snapshots:
       - encoding
       - supports-color
 
-  lerna@8.1.8(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(babel-plugin-macros@3.1.0)(encoding@0.1.13):
+  lerna@8.1.8(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(babel-plugin-macros@3.1.0)(encoding@0.1.13):
     dependencies:
-      '@lerna/create': 8.1.8(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.9.3)
+      '@lerna/create': 8.1.8(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))(babel-plugin-macros@3.1.0)(encoding@0.1.13)(typescript@5.9.3)
       '@npmcli/arborist': 7.5.4
       '@npmcli/package-json': 5.2.0
       '@npmcli/run-script': 8.1.0
-      '@nx/devkit': 17.3.2(nx@17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 17.3.2(nx@17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@octokit/plugin-enterprise-rest': 6.0.1
       '@octokit/rest': 19.0.11(encoding@0.1.13)
       aproba: 2.0.0
@@ -71735,7 +72003,7 @@ snapshots:
       npm-package-arg: 11.0.2
       npm-packlist: 8.0.2
       npm-registry-fetch: 17.1.0
-      nx: 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
+      nx: 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
       p-map: 4.0.0
       p-map-series: 2.1.0
       p-pipe: 3.1.0
@@ -73167,6 +73435,9 @@ snapshots:
       msgpackr-extract: 3.0.4
     optional: true
 
+  muggle-string@0.3.1:
+    optional: true
+
   multicast-dns@7.2.5:
     dependencies:
       dns-packet: 5.6.1
@@ -73676,7 +73947,7 @@ snapshots:
 
   nx@17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)):
     dependencies:
-      '@nrwl/tao': 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
+      '@nrwl/tao': 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.6
@@ -73728,7 +73999,7 @@ snapshots:
 
   nx@17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18)):
     dependencies:
-      '@nrwl/tao': 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
+      '@nrwl/tao': 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.6
@@ -73780,7 +74051,7 @@ snapshots:
 
   nx@17.3.2(@swc-node/register@1.10.2(@swc/core@1.6.13(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.6.13(@swc/helpers@0.5.18)):
     dependencies:
-      '@nrwl/tao': 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.5.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
+      '@nrwl/tao': 17.3.2(@swc-node/register@1.10.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.3))(@swc/core@1.15.8(@swc/helpers@0.5.18))
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.0-rc.46
       '@zkochan/js-yaml': 0.0.6
@@ -79632,7 +79903,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -81073,7 +81344,7 @@ snapshots:
       '@swc/core': 1.15.8(@swc/helpers@0.5.18)
       postcss: 8.5.6
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack@5.107.2):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
@@ -81883,6 +82154,26 @@ snapshots:
       '@swc/core': 1.15.8(@swc/helpers@0.5.18)
     optional: true
 
+  ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.39)(typescript@4.9.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 18.19.39
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.8(@swc/helpers@0.5.18)
+
   ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@18.19.39)(typescript@5.5.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -81903,7 +82194,7 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.18)
 
-  ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.5.3):
+  ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@20.9.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.12
@@ -81911,18 +82202,38 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 20.9.0
-      acorn: 8.16.0
+      acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.4
       make-error: 1.3.6
-      typescript: 5.5.3
+      typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.18)
     optional: true
+
+  ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@4.9.5):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 25.1.0
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.4
+      make-error: 1.3.6
+      typescript: 4.9.5
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.8(@swc/helpers@0.5.18)
 
   ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.5.3):
     dependencies:
@@ -81943,6 +82254,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.15.8(@swc/helpers@0.5.18)
+    optional: true
 
   ts-node@10.9.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@25.1.0)(typescript@5.9.3):
     dependencies:
@@ -81952,7 +82264,7 @@ snapshots:
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
       '@types/node': 25.1.0
-      acorn: 8.16.0
+      acorn: 8.15.0
       acorn-walk: 8.3.4
       arg: 4.1.3
       create-require: 1.1.1
@@ -82048,7 +82360,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tslint@6.1.3(typescript@5.5.3):
+  tslint@6.1.3(typescript@4.9.5):
     dependencies:
       '@babel/code-frame': 7.27.1
       builtin-modules: 1.1.1
@@ -82062,8 +82374,8 @@ snapshots:
       resolve: 1.22.11
       semver: 5.7.2
       tslib: 1.14.1
-      tsutils: 2.29.0(typescript@5.5.3)
-      typescript: 5.5.3
+      tsutils: 2.29.0(typescript@4.9.5)
+      typescript: 4.9.5
 
   tsscmp@1.0.6: {}
 
@@ -82125,10 +82437,10 @@ snapshots:
       - tsx
       - yaml
 
-  tsutils@2.29.0(typescript@5.5.3):
+  tsutils@2.29.0(typescript@4.9.5):
     dependencies:
       tslib: 1.14.1
-      typescript: 5.5.3
+      typescript: 4.9.5
 
   tsutils@3.21.0(typescript@4.9.5):
     dependencies:
@@ -82155,7 +82467,7 @@ snapshots:
   tuf-js@1.1.7:
     dependencies:
       '@tufjs/models': 1.0.4
-      debug: 4.4.3(supports-color@5.5.0)
+      debug: 4.4.3(supports-color@8.1.1)
       make-fetch-happen: 11.1.1
     transitivePeerDependencies:
       - supports-color
@@ -82436,7 +82748,7 @@ snapshots:
 
   unplugin@1.16.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       webpack-virtual-modules: 0.6.2
 
   unquote@1.1.1: {}
@@ -83260,6 +83572,46 @@ snapshots:
 
   vue-template-es2015-compiler@1.9.1: {}
 
+  vue-tsc@1.8.27(typescript@4.9.5):
+    dependencies:
+      '@volar/typescript': 1.11.1
+      '@vue/language-core': 1.8.27(typescript@4.9.5)
+      semver: 7.6.3
+      typescript: 4.9.5
+    optional: true
+
+  vue-tsc@1.8.27(typescript@5.0.4):
+    dependencies:
+      '@volar/typescript': 1.11.1
+      '@vue/language-core': 1.8.27(typescript@5.0.4)
+      semver: 7.6.3
+      typescript: 5.0.4
+    optional: true
+
+  vue-tsc@1.8.27(typescript@5.5.3):
+    dependencies:
+      '@volar/typescript': 1.11.1
+      '@vue/language-core': 1.8.27(typescript@5.5.3)
+      semver: 7.6.3
+      typescript: 5.5.3
+    optional: true
+
+  vue-tsc@1.8.27(typescript@5.6.2):
+    dependencies:
+      '@volar/typescript': 1.11.1
+      '@vue/language-core': 1.8.27(typescript@5.6.2)
+      semver: 7.6.3
+      typescript: 5.6.2
+    optional: true
+
+  vue-tsc@1.8.27(typescript@5.9.3):
+    dependencies:
+      '@volar/typescript': 1.11.1
+      '@vue/language-core': 1.8.27(typescript@5.9.3)
+      semver: 7.6.3
+      typescript: 5.9.3
+    optional: true
+
   vue@2.7.16:
     dependencies:
       '@vue/compiler-sfc': 2.7.16
@@ -83869,7 +84221,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 8.4.2
@@ -83910,7 +84262,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 8.4.2
@@ -83950,7 +84302,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 8.4.2
@@ -83990,7 +84342,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 8.4.2
@@ -84031,7 +84383,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 8.4.2
@@ -84071,7 +84423,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 8.4.2
@@ -84112,7 +84464,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 8.4.2
@@ -84152,7 +84504,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 10.2.0
@@ -84193,7 +84545,7 @@ snapshots:
       express: 4.22.1
       graceful-fs: 4.2.11
       html-entities: 2.6.0
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 10.2.0
@@ -84233,7 +84585,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.22.1
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 10.2.0
@@ -84310,7 +84662,7 @@ snapshots:
       connect-history-api-fallback: 2.0.0
       express: 4.22.1
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.9(@types/express@4.17.21)
+      http-proxy-middleware: 2.0.9(@types/express@4.17.21)(debug@4.4.3)
       ipaddr.js: 2.3.0
       launch-editor: 2.12.0
       open: 10.2.0
@@ -84967,7 +85319,7 @@ snapshots:
       watchpack: 2.5.1
       webpack-sources: 3.3.4
     optionalDependencies:
-      webpack-cli: 5.1.4(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.0.4)(webpack@5.105.3)
+      webpack-cli: 5.1.4(webpack-dev-server@4.11.1)(webpack@5.105.3)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -85458,7 +85810,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.0
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack@5.107.2)
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack@5.107.2(@swc/core@1.15.8(@swc/helpers@0.5.18))(webpack-cli@5.1.4))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     optionalDependencies:


### PR DESCRIPTION
## Summary
- remove the root TypeScript devDependency so examples do not compile through a workspace fallback
- add local TypeScript where the dynamic Node TypeScript host actually needs it
- align Angular Universal SSR examples with Angular 15's supported TypeScript range
- declare Analog's missing compiler-cli peer in the existing package extension so the Vite Angular examples resolve Angular 20 correctly

## Verification
- PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 pnpm install --frozen-lockfile --filter angular-universal-ssr_client-app --filter angular-universal-ssr_host-app --filter dynamic-remotes-node-typescript-host --filter module-federation-vite-angular-host --filter module-federation-vite-angular-remote
- node -p "try { require.resolve('typescript/package.json') } catch (e) { e.code }" && test ! -e node_modules/typescript
- pnpm --filter module-federation-vite-angular-host build
- pnpm --filter module-federation-vite-angular-remote build
- pnpm --filter dynamic-remotes-node-typescript-host exec webpack --config webpack.config.js
- pnpm test
- git diff --check
- tracedecay tool diff_context / simplify_scan / affected on changed manifests

## Notes
Remaining install warnings are existing non-TypeScript peer mismatches in Angular Universal SSR and Rspack.