### PR TITLE
docs: add GA4 README tracking pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,6 @@ Start for free today at [zephyr-cloud.io](https://zephyr-cloud.io).
 The examples in this repository leverage [pnpm](https://pnpm.io/) and workspaces. To run from a git checkout locally, remove all of the proprietary example directories, ensure you have pnpm installed and run install `pnpm i` at the repo root.
 You can then run `pnpm start` from any of the non-proprietary examples. Some examples may use a different command such as "dev" or "serve".
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/ModuleFederationExamplesRoot">
-
 Module federation will work with any type of file that you're able to import, that Webpack understands how to process. It is not a JS only, or React only feature. Images, CSS, JSON, WASM, and anything else can be federated.
 
 ## Companies using Module Federation
@@ -104,3 +102,5 @@ Module federation will work with any type of file that you're able to import, th
 # Contribution to this repo
 
 You decided to contribute to this project? Great, thanks a lot for pushing it!
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=root&ep.readme_path=README.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2F&dt=ModuleFederationExamples+README.md">

--- a/advanced-api/README.md
+++ b/advanced-api/README.md
@@ -25,3 +25,5 @@ pnpm --filter dynamic-remotes_* build
 ```
 
 See each example's README for detailed instructions.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=advanced-api&ep.readme_path=advanced-api%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fadvanced-api&dt=ModuleFederationExamples+advanced-api%2FREADME.md">

--- a/advanced-api/automatic-vendor-sharing/README.md
+++ b/advanced-api/automatic-vendor-sharing/README.md
@@ -503,3 +503,5 @@ When contributing to this example:
 ---
 
 **Note**: This example demonstrates production-ready patterns for Module Federation with automatic vendor sharing. The enhanced error handling, performance monitoring, and optimization techniques shown here are suitable for real-world applications.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=advanced-api&ep.readme_path=advanced-api%2Fautomatic-vendor-sharing%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fadvanced-api%2Fautomatic-vendor-sharing&dt=ModuleFederationExamples+advanced-api%2Fautomatic-vendor-sharing%2FREADME.md">

--- a/advanced-api/dynamic-remotes-runtime-environment-variables/README.md
+++ b/advanced-api/dynamic-remotes-runtime-environment-variables/README.md
@@ -610,3 +610,5 @@ This project is part of the Module Federation examples repository.
 ---
 
 **Need help?** Check the [troubleshooting section](#troubleshooting) or open an issue in the repository.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=advanced-api&ep.readme_path=advanced-api%2Fdynamic-remotes-runtime-environment-variables%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fadvanced-api%2Fdynamic-remotes-runtime-environment-variables&dt=ModuleFederationExamples+advanced-api%2Fdynamic-remotes-runtime-environment-variables%2FREADME.md">

--- a/advanced-api/dynamic-remotes-synchronous-imports/README.md
+++ b/advanced-api/dynamic-remotes-synchronous-imports/README.md
@@ -413,3 +413,5 @@ MIT License - see the [LICENSE](../../LICENSE) file for details.
 ---
 
 **⭐ Key Takeaway**: This example demonstrates that you can have the best of both worlds - the simplicity and developer experience of synchronous imports combined with the flexibility of dynamic remote URL resolution at runtime.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=advanced-api&ep.readme_path=advanced-api%2Fdynamic-remotes-synchronous-imports%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fadvanced-api%2Fdynamic-remotes-synchronous-imports&dt=ModuleFederationExamples+advanced-api%2Fdynamic-remotes-synchronous-imports%2FREADME.md">

--- a/advanced-api/dynamic-remotes/README.md
+++ b/advanced-api/dynamic-remotes/README.md
@@ -460,3 +460,5 @@ The E2E tests verify:
 3. **Long-term**: Explore advanced micro-frontend patterns and tooling
 
 This example serves as a foundation for understanding Module Federation's dynamic capabilities while highlighting areas for production-ready improvements.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=advanced-api&ep.readme_path=advanced-api%2Fdynamic-remotes%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fadvanced-api%2Fdynamic-remotes&dt=ModuleFederationExamples+advanced-api%2Fdynamic-remotes%2FREADME.md">

--- a/angular-universal-ssr/README.md
+++ b/angular-universal-ssr/README.md
@@ -12,3 +12,5 @@ ports `4000`, `5000`, respectively.
 - [localhost:3000](http://localhost:3000/) (HOST_APP)
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=angular-universal-ssr&ep.readme_path=angular-universal-ssr%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fangular-universal-ssr&dt=ModuleFederationExamples+angular-universal-ssr%2FREADME.md">

--- a/angular-universal-ssr/client-app/README.md
+++ b/angular-universal-ssr/client-app/README.md
@@ -25,3 +25,5 @@ Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protrac
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=angular-universal-ssr&ep.readme_path=angular-universal-ssr%2Fclient-app%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fangular-universal-ssr%2Fclient-app&dt=ModuleFederationExamples+angular-universal-ssr%2Fclient-app%2FREADME.md">

--- a/angular-universal-ssr/host-app/README.md
+++ b/angular-universal-ssr/host-app/README.md
@@ -25,3 +25,5 @@ Run `ng e2e` to execute the end-to-end tests via [Protractor](http://www.protrac
 ## Further help
 
 To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=angular-universal-ssr&ep.readme_path=angular-universal-ssr%2Fhost-app%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fangular-universal-ssr%2Fhost-app&dt=ModuleFederationExamples+angular-universal-ssr%2Fhost-app%2FREADME.md">

--- a/apollo-client/README.md
+++ b/apollo-client/README.md
@@ -17,3 +17,5 @@ Bellow you can see the port mapping:
 
 - [localhost:3000](http://localhost:3000/) (app1)
 - [localhost:3001](http://localhost:3001/) (app2)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=apollo-client&ep.readme_path=apollo-client%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fapollo-client&dt=ModuleFederationExamples+apollo-client%2FREADME.md">

--- a/basic-host-remote/README.md
+++ b/basic-host-remote/README.md
@@ -12,6 +12,6 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/BasicRemoteHost">
-
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=basic-host-remote&ep.readme_path=basic-host-remote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fbasic-host-remote&dt=ModuleFederationExamples+basic-host-remote%2FREADME.md">

--- a/basic-host-remote/app1/README.md
+++ b/basic-host-remote/app1/README.md
@@ -35,3 +35,5 @@ yarn serve
 ```
 
 For more information, see the [Modern.js documentation](https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=basic-host-remote&ep.readme_path=basic-host-remote%2Fapp1%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fbasic-host-remote%2Fapp1&dt=ModuleFederationExamples+basic-host-remote%2Fapp1%2FREADME.md">

--- a/basic-host-remote/app2/README.md
+++ b/basic-host-remote/app2/README.md
@@ -35,3 +35,5 @@ yarn serve
 ```
 
 For more information, see the [Modern.js documentation](https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=basic-host-remote&ep.readme_path=basic-host-remote%2Fapp2%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fbasic-host-remote%2Fapp2&dt=ModuleFederationExamples+basic-host-remote%2Fapp2%2FREADME.md">

--- a/bi-directional/README.md
+++ b/bi-directional/README.md
@@ -81,3 +81,5 @@ The test suite includes:
 3. **Modern.js Framework**: Latest patterns and best practices
 4. **Production-Ready Testing**: Comprehensive Playwright test suite
 5. **TypeScript Support**: Full type safety across federated modules
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=bi-directional&ep.readme_path=bi-directional%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fbi-directional&dt=ModuleFederationExamples+bi-directional%2FREADME.md">

--- a/bi-directional/app1/README.md
+++ b/bi-directional/app1/README.md
@@ -54,3 +54,5 @@ The module federation setup is configured inline in `modern.config.js` via `modu
 - **Error Boundaries**: Graceful handling of federation failures
 
 For more information, see the [Modern.js documentation](https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=bi-directional&ep.readme_path=bi-directional%2Fapp1%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fbi-directional%2Fapp1&dt=ModuleFederationExamples+bi-directional%2Fapp1%2FREADME.md">

--- a/bi-directional/app2/README.md
+++ b/bi-directional/app2/README.md
@@ -54,3 +54,5 @@ The module federation setup is configured inline in `modern.config.js` via `modu
 - **Error Boundaries**: Graceful handling of federation failures
 
 For more information, see the [Modern.js documentation](https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=bi-directional&ep.readme_path=bi-directional%2Fapp2%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fbi-directional%2Fapp2&dt=ModuleFederationExamples+bi-directional%2Fapp2%2FREADME.md">

--- a/clo/README.md
+++ b/clo/README.md
@@ -21,3 +21,5 @@ Run `pnpm run start`. This will build and serve both `host` and `remote` on port
 To run tests in interactive UI mode, run `pnpm test:e2e:ui`.
 
 To build the apps, start both servers, and run tests in headless mode, run `pnpm e2e:ci`.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=clo&ep.readme_path=clo%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fclo&dt=ModuleFederationExamples+clo%2FREADME.md">

--- a/cloud/azure-functions-node-v4/README.md
+++ b/cloud/azure-functions-node-v4/README.md
@@ -26,3 +26,5 @@ Then run:
 - npm run start
 - visit [http://localhost:7071/api/app](http://localhost:7071/api/app) for the SSR app
 - visit [http://localhost:8080/client](http://localhost:8080/client) for the CSR app
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=cloud&ep.readme_path=cloud%2Fazure-functions-node-v4%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fcloud%2Fazure-functions-node-v4&dt=ModuleFederationExamples+cloud%2Fazure-functions-node-v4%2FREADME.md">

--- a/complete-react-case/README.md
+++ b/complete-react-case/README.md
@@ -32,3 +32,5 @@ It is a pure host.
 After running these commands, open your browser at `http://localhost:3002` and open the DevTools network tab to see resource loading details.
 
 [Best practices, rules and more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=complete-react-case&ep.readme_path=complete-react-case%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fcomplete-react-case&dt=ModuleFederationExamples+complete-react-case%2FREADME.md">

--- a/comprehensive-demo-react16/README.md
+++ b/comprehensive-demo-react16/README.md
@@ -16,6 +16,7 @@ Included apps:
 - App #3 (ReactJS): [http://localhost:3003](http://localhost:3003)
 - App #4 (SvelteJS): [http://localhost:3004](http://localhost:3004)
 - App #5 (LitElement): [http://localhost:3005](http://localhost:3005)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/ComprehensiveDemo">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=comprehensive-demo-react16&ep.readme_path=comprehensive-demo-react16%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fcomprehensive-demo-react16&dt=ModuleFederationExamples+comprehensive-demo-react16%2FREADME.md">

--- a/comprehensive-demo-react16/app-04/README.md
+++ b/comprehensive-demo-react16/app-04/README.md
@@ -60,3 +60,5 @@ Then, from within your project folder:
 npm run build
 surge public
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=comprehensive-demo-react16&ep.readme_path=comprehensive-demo-react16%2Fapp-04%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fcomprehensive-demo-react16%2Fapp-04&dt=ModuleFederationExamples+comprehensive-demo-react16%2Fapp-04%2FREADME.md">

--- a/comprehensive-demo-react18/README.md
+++ b/comprehensive-demo-react18/README.md
@@ -16,7 +16,6 @@ Included apps:
 - App #3 (ReactJS): [http://localhost:3003](http://localhost:3003)
 - App #4 (SvelteJS): [http://localhost:3004](http://localhost:3004)
 - App #5 (LitElement): [http://localhost:3005](http://localhost:3005)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/ComprehensiveDemo">
 
 # Running Playwright E2E Tests
 
@@ -25,3 +24,5 @@ To run the Playwright test suite locally in headless mode, execute `pnpm test:e2
 For an interactive UI to debug or explore tests, run `pnpm test:e2e:ui`.
 
 In CI scenarios run `pnpm e2e:ci`. This command builds the applications, installs the required Playwright browsers and runs the tests with a concise reporter.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=comprehensive-demo-react18&ep.readme_path=comprehensive-demo-react18%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fcomprehensive-demo-react18&dt=ModuleFederationExamples+comprehensive-demo-react18%2FREADME.md">

--- a/comprehensive-demo-react18/app-04/README.md
+++ b/comprehensive-demo-react18/app-04/README.md
@@ -60,3 +60,5 @@ Then, from within your project folder:
 npm run build
 surge public
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=comprehensive-demo-react18&ep.readme_path=comprehensive-demo-react18%2Fapp-04%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fcomprehensive-demo-react18%2Fapp-04&dt=ModuleFederationExamples+comprehensive-demo-react18%2Fapp-04%2FREADME.md">

--- a/cra/README.md
+++ b/cra/README.md
@@ -22,3 +22,5 @@ Run the following commands from this directory:
 - `pnpm e2e:ci`: installs the required browsers (when needed) and executes the suite with a list reporter while collecting failure artifacts (traces, screenshots, videos).
 
 > **Note:** The first Playwright run may require downloading browser binaries. If they are not already installed you can run `pnpm exec playwright install` once to prepare the environment.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=cra&ep.readme_path=cra%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fcra&dt=ModuleFederationExamples+cra%2FREADME.md">

--- a/css-isolation/README.md
+++ b/css-isolation/README.md
@@ -38,8 +38,6 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/BasicRemoteHost">
-
 # Running Playwright E2E Tests
 
 Run `pnpm test:e2e` from this workspace to execute the Playwright end-to-end suite against the development servers configured in [`playwright.config.ts`](./playwright.config.ts).
@@ -50,3 +48,5 @@ For local debugging you can use the helper scripts:
 - `pnpm test:e2e:debug` to launch the suite with Playwright's debug tools enabled.
 
 In CI environments run `pnpm e2e:ci` to install the required browsers and execute the tests in headless mode. Use `pnpm legacy:e2e:ci` (or set `LEGACY_START=true`) to run the same checks against the legacy Webpack builds.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=css-isolation&ep.readme_path=css-isolation%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fcss-isolation&dt=ModuleFederationExamples+css-isolation%2FREADME.md">

--- a/dashboard-admin-react-rspack-material-ui/README.md
+++ b/dashboard-admin-react-rspack-material-ui/README.md
@@ -23,3 +23,5 @@ Open [http://localhost:3001](http://localhost:3001) to view Webpack 5 module fed
 Open [http://localhost:3002](http://localhost:3002) to view Webpack 5 module federated Navigation App\
 Open [http://localhost:3003](http://localhost:3003) to view Webpack 5 module federated FAQ App\
 Open [http://localhost:3004](http://localhost:3004) to view Rspack module federated Team App
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=dashboard-admin-react-rspack-material-ui&ep.readme_path=dashboard-admin-react-rspack-material-ui%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdashboard-admin-react-rspack-material-ui&dt=ModuleFederationExamples+dashboard-admin-react-rspack-material-ui%2FREADME.md">

--- a/different-react-versions-16-17-typescript/README.md
+++ b/different-react-versions-16-17-typescript/README.md
@@ -18,4 +18,4 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/DifferentReactVersions">
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=different-react-versions-16-17-typescript&ep.readme_path=different-react-versions-16-17-typescript%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdifferent-react-versions-16-17-typescript&dt=ModuleFederationExamples+different-react-versions-16-17-typescript%2FREADME.md">

--- a/different-react-versions-16-17/README.md
+++ b/different-react-versions-16-17/README.md
@@ -1,3 +1,5 @@
 # Example has moved
 
 For an example implementation of using different React versions together with Module Federation, check out the runtime plugin folder [runtime-plugins/multiple-react-versions](https://github.com/module-federation/module-federation-examples/tree/master/runtime-plugins/multiple-react-versions).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=different-react-versions-16-17&ep.readme_path=different-react-versions-16-17%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdifferent-react-versions-16-17&dt=ModuleFederationExamples+different-react-versions-16-17%2FREADME.md">

--- a/different-react-versions-16-18/README.md
+++ b/different-react-versions-16-18/README.md
@@ -18,4 +18,4 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/DifferentReactVersions">
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=different-react-versions-16-18&ep.readme_path=different-react-versions-16-18%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdifferent-react-versions-16-18&dt=ModuleFederationExamples+different-react-versions-16-18%2FREADME.md">

--- a/different-react-versions-isolated/README.md
+++ b/different-react-versions-isolated/README.md
@@ -14,6 +14,6 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/BasicRemoteHost">
-
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=different-react-versions-isolated&ep.readme_path=different-react-versions-isolated%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdifferent-react-versions-isolated&dt=ModuleFederationExamples+different-react-versions-isolated%2FREADME.md">

--- a/different-react-versions-typescript/README.md
+++ b/different-react-versions-typescript/README.md
@@ -77,4 +77,4 @@ import type { ButtonProps } from 'app2/Button';
 />;
 ```
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/DifferentReactVersionsTypescript">
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=different-react-versions-typescript&ep.readme_path=different-react-versions-typescript%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdifferent-react-versions-typescript&dt=ModuleFederationExamples+different-react-versions-typescript%2FREADME.md">

--- a/different-react-versions/README.md
+++ b/different-react-versions/README.md
@@ -56,6 +56,6 @@ This component is responsible to render the federated component using the remote
 />
 ```
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/DifferentReactVersions">
-
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=different-react-versions&ep.readme_path=different-react-versions%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdifferent-react-versions&dt=ModuleFederationExamples+different-react-versions%2FREADME.md">

--- a/dynamic-remotes-node-typescript/README.md
+++ b/dynamic-remotes-node-typescript/README.md
@@ -7,3 +7,5 @@ This allows you to dynamically load remote containers on the server.
 `pnpm run start` will initiate a build and http server, then the node will load the remotes. The host will poll for changes on the remote and reload when they are detected.
 
 NOTE: HMR is not supported on the server side yet, so we can't get notified of changes in the remote. We have to poll for changes.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=dynamic-remotes-node-typescript&ep.readme_path=dynamic-remotes-node-typescript%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdynamic-remotes-node-typescript&dt=ModuleFederationExamples+dynamic-remotes-node-typescript%2FREADME.md">

--- a/dynamic-remotes-node/README.md
+++ b/dynamic-remotes-node/README.md
@@ -7,3 +7,5 @@ This allows you to dynamically load remote containers on the server.
 `pnpm run start` will initiate a build and http server, then the node will load the remotes. The host will poll for changes on the remote and reload when they are detected.
 
 NOTE: HMR is not supported on the server side yet, so we can't get notified of changes in the remote. We have to poll for changes.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=dynamic-remotes-node&ep.readme_path=dynamic-remotes-node%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdynamic-remotes-node&dt=ModuleFederationExamples+dynamic-remotes-node%2FREADME.md">

--- a/dynamic-system-host/README.md
+++ b/dynamic-system-host/README.md
@@ -15,6 +15,7 @@ ports `3001`, `3002`, and `3003` respectively.
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
 - [localhost:3003](http://localhost:3003/) (STANDALONE REMOTE)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/DynamicSystemHost">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=dynamic-system-host&ep.readme_path=dynamic-system-host%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fdynamic-system-host&dt=ModuleFederationExamples+dynamic-system-host%2FREADME.md">

--- a/error-boundary/README.md
+++ b/error-boundary/README.md
@@ -2,3 +2,5 @@
 
 This demo boots only app1, app2 remains offline.
 Loading localhost:3001 will render a error message from the runtime plugin as a react module when the container if offline.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=error-boundary&ep.readme_path=error-boundary%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ferror-boundary&dt=ModuleFederationExamples+error-boundary%2FREADME.md">

--- a/federated-css-react-ssr/README.md
+++ b/federated-css-react-ssr/README.md
@@ -243,3 +243,5 @@ Shells
 - [localhost:4000](http://localhost:4003/) (SHELL JSS-STYLED-COMPONENTS-CSS-MODULE)
 - [localhost:4000](http://localhost:4004/) (SHELL LESS-SCSS)
 - [localhost:4000](http://localhost:4005/) (SHELL SCSS-TAILWIND)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=federated-css-react-ssr&ep.readme_path=federated-css-react-ssr%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffederated-css-react-ssr&dt=ModuleFederationExamples+federated-css-react-ssr%2FREADME.md">

--- a/federated-css/README.md
+++ b/federated-css/README.md
@@ -90,4 +90,5 @@ Note. you don't need to start required remotes separately for this command.
 - [localhost:4006](http://localhost:4006/) (STANDALONE REMOTE)
 - [localhost:4007](http://localhost:4007/) (STANDALONE REMOTE)
 - [localhost:4008](http://localhost:4008/) (STANDALONE REMOTE)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/FederatedStyles">
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=federated-css&ep.readme_path=federated-css%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffederated-css&dt=ModuleFederationExamples+federated-css%2FREADME.md">

--- a/federated-css/consumers-nextjs/any-combination/README.md
+++ b/federated-css/consumers-nextjs/any-combination/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=federated-css&ep.readme_path=federated-css%2Fconsumers-nextjs%2Fany-combination%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffederated-css%2Fconsumers-nextjs%2Fany-combination&dt=ModuleFederationExamples+federated-css%2Fconsumers-nextjs%2Fany-combination%2FREADME.md">

--- a/federated-css/consumers-nextjs/combination-of-4/README.md
+++ b/federated-css/consumers-nextjs/combination-of-4/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=federated-css&ep.readme_path=federated-css%2Fconsumers-nextjs%2Fcombination-of-4%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffederated-css%2Fconsumers-nextjs%2Fcombination-of-4&dt=ModuleFederationExamples+federated-css%2Fconsumers-nextjs%2Fcombination-of-4%2FREADME.md">

--- a/federated-css/consumers-nextjs/jss-and-tailwind-global/README.md
+++ b/federated-css/consumers-nextjs/jss-and-tailwind-global/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=federated-css&ep.readme_path=federated-css%2Fconsumers-nextjs%2Fjss-and-tailwind-global%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffederated-css%2Fconsumers-nextjs%2Fjss-and-tailwind-global&dt=ModuleFederationExamples+federated-css%2Fconsumers-nextjs%2Fjss-and-tailwind-global%2FREADME.md">

--- a/federated-css/consumers-nextjs/jss-css-and-tailwind-module/README.md
+++ b/federated-css/consumers-nextjs/jss-css-and-tailwind-module/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=federated-css&ep.readme_path=federated-css%2Fconsumers-nextjs%2Fjss-css-and-tailwind-module%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffederated-css%2Fconsumers-nextjs%2Fjss-css-and-tailwind-module&dt=ModuleFederationExamples+federated-css%2Fconsumers-nextjs%2Fjss-css-and-tailwind-module%2FREADME.md">

--- a/federated-css/consumers-nextjs/less-and-styled-component/README.md
+++ b/federated-css/consumers-nextjs/less-and-styled-component/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=federated-css&ep.readme_path=federated-css%2Fconsumers-nextjs%2Fless-and-styled-component%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffederated-css%2Fconsumers-nextjs%2Fless-and-styled-component&dt=ModuleFederationExamples+federated-css%2Fconsumers-nextjs%2Fless-and-styled-component%2FREADME.md">

--- a/federated-library-from-cdn/README.md
+++ b/federated-library-from-cdn/README.md
@@ -37,3 +37,5 @@ npm run build
 ```
 npm run start
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=federated-library-from-cdn&ep.readme_path=federated-library-from-cdn%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffederated-library-from-cdn&dt=ModuleFederationExamples+federated-library-from-cdn%2FREADME.md">

--- a/federated-npm/README.md
+++ b/federated-npm/README.md
@@ -12,6 +12,6 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/BasicRemoteHost">
-
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=federated-npm&ep.readme_path=federated-npm%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffederated-npm&dt=ModuleFederationExamples+federated-npm%2FREADME.md">

--- a/frontend-discovery-service/README.md
+++ b/frontend-discovery-service/README.md
@@ -212,3 +212,5 @@ For more details on consumer stickiness and how it influences the traffic shifti
 ## 7. Wrapping Up
 
 When running Frontend Service Discovery on AWS in a production environment, it's essential to meticulously configure Cross-Origin Resource Sharing (CORS) to guarantee secure requests. In order to do that, make sure you have accurate values for `AccessControlAllowOrigin` and `CookieSettings` values.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=frontend-discovery-service&ep.readme_path=frontend-discovery-service%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ffrontend-discovery-service&dt=ModuleFederationExamples+frontend-discovery-service%2FREADME.md">

--- a/genesis/README.md
+++ b/genesis/README.md
@@ -11,3 +11,5 @@ Run `yarn && yarn dev` or `yarn && yarn build && pnpm run start`
 
 - [localhost:3001](http://localhost:3001) (ssr-mf-home)
 - [localhost:3002](http://localhost:3002/about) (ssr-mf-about)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=genesis&ep.readme_path=genesis%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fgenesis&dt=ModuleFederationExamples+genesis%2FREADME.md">

--- a/i18next-nextjs-react/README.md
+++ b/i18next-nextjs-react/README.md
@@ -32,3 +32,5 @@ This is a micro frontend, using a dedicated i18next instance for internationaliz
 A shared lib sharing a module to handle i18next instances
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=i18next-nextjs-react&ep.readme_path=i18next-nextjs-react%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fi18next-nextjs-react&dt=ModuleFederationExamples+i18next-nextjs-react%2FREADME.md">

--- a/i18next-nextjs-react/i18next-shared-lib/README.md
+++ b/i18next-nextjs-react/i18next-shared-lib/README.md
@@ -31,3 +31,5 @@ This function is used by the hook to create the instance with the language resou
 This hook takes two parameters, an instance name, and an i18next.Resource object, and it returns a function taking
 a filename in parameter that returns a version of i18next useTranslation(filename) contextualized with the instance
 identified with the given instance name and using the given language resources.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=i18next-nextjs-react&ep.readme_path=i18next-nextjs-react%2Fi18next-shared-lib%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fi18next-nextjs-react%2Fi18next-shared-lib&dt=ModuleFederationExamples+i18next-nextjs-react%2Fi18next-shared-lib%2FREADME.md">

--- a/i18next-nextjs-react/next-host/README.md
+++ b/i18next-nextjs-react/next-host/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=i18next-nextjs-react&ep.readme_path=i18next-nextjs-react%2Fnext-host%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fi18next-nextjs-react%2Fnext-host&dt=ModuleFederationExamples+i18next-nextjs-react%2Fnext-host%2FREADME.md">

--- a/i18next-nextjs-react/react-host/README.md
+++ b/i18next-nextjs-react/react-host/README.md
@@ -1,1 +1,3 @@
 JSON enabling
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=i18next-nextjs-react&ep.readme_path=i18next-nextjs-react%2Freact-host%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fi18next-nextjs-react%2Freact-host&dt=ModuleFederationExamples+i18next-nextjs-react%2Freact-host%2FREADME.md">

--- a/loadable-react-16/README.md
+++ b/loadable-react-16/README.md
@@ -19,3 +19,5 @@ Bellow you can see the port mapping:
 
 - [localhost:3000](http://localhost:3000/) (app1)
 - [localhost:3001](http://localhost:3001/) (app2)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=loadable-react-16&ep.readme_path=loadable-react-16%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Floadable-react-16&dt=ModuleFederationExamples+loadable-react-16%2FREADME.md">

--- a/loadable-react-18/README.md
+++ b/loadable-react-18/README.md
@@ -19,3 +19,5 @@ Bellow you can see the port mapping:
 
 - [localhost:3000](http://localhost:3000/) (app1)
 - [localhost:3001](http://localhost:3001/) (app2)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=loadable-react-18&ep.readme_path=loadable-react-18%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Floadable-react-18&dt=ModuleFederationExamples+loadable-react-18%2FREADME.md">

--- a/modernjs-classic-tractor-example/README.md
+++ b/modernjs-classic-tractor-example/README.md
@@ -27,3 +27,5 @@ pnpm dev
 ```
 
 Go to http://localhost:3000
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs-classic-tractor-example&ep.readme_path=modernjs-classic-tractor-example%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs-classic-tractor-example&dt=ModuleFederationExamples+modernjs-classic-tractor-example%2FREADME.md">

--- a/modernjs-classic-tractor-example/checkout/README.md
+++ b/modernjs-classic-tractor-example/checkout/README.md
@@ -35,3 +35,5 @@ pnpm serve
 ```
 
 For more information, see the [Modern.js documentation](https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs-classic-tractor-example&ep.readme_path=modernjs-classic-tractor-example%2Fcheckout%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs-classic-tractor-example%2Fcheckout&dt=ModuleFederationExamples+modernjs-classic-tractor-example%2Fcheckout%2FREADME.md">

--- a/modernjs-classic-tractor-example/decide/README.md
+++ b/modernjs-classic-tractor-example/decide/README.md
@@ -35,3 +35,5 @@ pnpm serve
 ```
 
 For more information, see the [Modern.js documentation](https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs-classic-tractor-example&ep.readme_path=modernjs-classic-tractor-example%2Fdecide%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs-classic-tractor-example%2Fdecide&dt=ModuleFederationExamples+modernjs-classic-tractor-example%2Fdecide%2FREADME.md">

--- a/modernjs-classic-tractor-example/explore/README.md
+++ b/modernjs-classic-tractor-example/explore/README.md
@@ -35,3 +35,5 @@ pnpm serve
 ```
 
 For more information, see the [Modern.js documentation](https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs-classic-tractor-example&ep.readme_path=modernjs-classic-tractor-example%2Fexplore%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs-classic-tractor-example%2Fexplore&dt=ModuleFederationExamples+modernjs-classic-tractor-example%2Fexplore%2FREADME.md">

--- a/modernjs-ssr/README.md
+++ b/modernjs-ssr/README.md
@@ -11,3 +11,5 @@ Run `pnpm run start`. This will build and serve both `host` and `provider` on po
 
 - [localhost:3007](http://localhost:3007/) (HOST)
 - [localhost:3006](http://localhost:3006/) (STANDALONE REMOTE)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs-ssr&ep.readme_path=modernjs-ssr%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs-ssr&dt=ModuleFederationExamples+modernjs-ssr%2FREADME.md">

--- a/modernjs-ssr/dynamic-provider/README.md
+++ b/modernjs-ssr/dynamic-provider/README.md
@@ -35,3 +35,5 @@ yarn serve
 ```
 
 For more information, see the [Modern.js documentation](​https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs-ssr&ep.readme_path=modernjs-ssr%2Fdynamic-provider%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs-ssr%2Fdynamic-provider&dt=ModuleFederationExamples+modernjs-ssr%2Fdynamic-provider%2FREADME.md">

--- a/modernjs-ssr/host/README.md
+++ b/modernjs-ssr/host/README.md
@@ -35,3 +35,5 @@ yarn serve
 ```
 
 For more information, see the [Modern.js documentation](​https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs-ssr&ep.readme_path=modernjs-ssr%2Fhost%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs-ssr%2Fhost&dt=ModuleFederationExamples+modernjs-ssr%2Fhost%2FREADME.md">

--- a/modernjs-ssr/provider/README.md
+++ b/modernjs-ssr/provider/README.md
@@ -35,3 +35,5 @@ yarn serve
 ```
 
 For more information, see the [Modern.js documentation](​https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs-ssr&ep.readme_path=modernjs-ssr%2Fprovider%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs-ssr%2Fprovider&dt=ModuleFederationExamples+modernjs-ssr%2Fprovider%2FREADME.md">

--- a/modernjs/README.md
+++ b/modernjs/README.md
@@ -11,3 +11,5 @@ Run `pnpm run start`. This will build and serve both `host` and `provider` on po
 
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs&ep.readme_path=modernjs%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs&dt=ModuleFederationExamples+modernjs%2FREADME.md">

--- a/modernjs/host/README.md
+++ b/modernjs/host/README.md
@@ -35,3 +35,5 @@ yarn serve
 ```
 
 For more information, see the [Modern.js documentation](​https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs&ep.readme_path=modernjs%2Fhost%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs%2Fhost&dt=ModuleFederationExamples+modernjs%2Fhost%2FREADME.md">

--- a/modernjs/provider/README.md
+++ b/modernjs/provider/README.md
@@ -35,3 +35,5 @@ yarn serve
 ```
 
 For more information, see the [Modern.js documentation](​https://modernjs.dev/en).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=modernjs&ep.readme_path=modernjs%2Fprovider%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodernjs%2Fprovider&dt=ModuleFederationExamples+modernjs%2Fprovider%2FREADME.md">

--- a/module-federation-vite-angular/README.md
+++ b/module-federation-vite-angular/README.md
@@ -10,3 +10,5 @@ From this directory execute:
 Open your browser at http://localhost:5173/ to see the amazing result
 
 ![screenshot](docs/screenshot.png)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=module-federation-vite-angular&ep.readme_path=module-federation-vite-angular%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodule-federation-vite-angular&dt=ModuleFederationExamples+module-federation-vite-angular%2FREADME.md">

--- a/module-federation-vite-react/README.md
+++ b/module-federation-vite-react/README.md
@@ -10,3 +10,5 @@ From this directory execute:
 Open your browser at http://localhost:4173/ to see the amazing result
 
 ![screenshot](docs/screenshot.png)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=module-federation-vite-react&ep.readme_path=module-federation-vite-react%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodule-federation-vite-react&dt=ModuleFederationExamples+module-federation-vite-react%2FREADME.md">

--- a/module-federation-vite-solid/README.md
+++ b/module-federation-vite-solid/README.md
@@ -10,3 +10,5 @@ From this directory execute:
 Open your browser at http://localhost:4173/ to see the amazing result
 
 ![screenshot](docs/screenshot.png)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=module-federation-vite-solid&ep.readme_path=module-federation-vite-solid%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodule-federation-vite-solid&dt=ModuleFederationExamples+module-federation-vite-solid%2FREADME.md">

--- a/module-federation-vite-svelte/README.md
+++ b/module-federation-vite-svelte/README.md
@@ -10,3 +10,5 @@ From this directory execute:
 Open your browser at http://localhost:4173/ to see the amazing result
 
 ![screenshot](docs/screenshot.png)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=module-federation-vite-svelte&ep.readme_path=module-federation-vite-svelte%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodule-federation-vite-svelte&dt=ModuleFederationExamples+module-federation-vite-svelte%2FREADME.md">

--- a/module-federation-vite-svelte/host/README.md
+++ b/module-federation-vite-svelte/host/README.md
@@ -46,3 +46,5 @@ If you have state that's important to retain within a component, consider creati
 import { writable } from 'svelte/store';
 export default writable(0);
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=module-federation-vite-svelte&ep.readme_path=module-federation-vite-svelte%2Fhost%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodule-federation-vite-svelte%2Fhost&dt=ModuleFederationExamples+module-federation-vite-svelte%2Fhost%2FREADME.md">

--- a/module-federation-vite-svelte/remote/README.md
+++ b/module-federation-vite-svelte/remote/README.md
@@ -46,3 +46,5 @@ If you have state that's important to retain within a component, consider creati
 import { writable } from 'svelte/store';
 export default writable(0);
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=module-federation-vite-svelte&ep.readme_path=module-federation-vite-svelte%2Fremote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodule-federation-vite-svelte%2Fremote&dt=ModuleFederationExamples+module-federation-vite-svelte%2Fremote%2FREADME.md">

--- a/module-federation-vite-vue3/README.md
+++ b/module-federation-vite-vue3/README.md
@@ -12,3 +12,5 @@ Open your browser at http://localhost:5173/ to see the amazing result
 ![screenshot](docs/screenshot.png)
 
 The state is shared between applications
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=module-federation-vite-vue3&ep.readme_path=module-federation-vite-vue3%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodule-federation-vite-vue3&dt=ModuleFederationExamples+module-federation-vite-vue3%2FREADME.md">

--- a/module-federation-vite-vue3/host/README.md
+++ b/module-federation-vite-vue3/host/README.md
@@ -44,3 +44,5 @@ npm run build
 ```sh
 npm run lint
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=module-federation-vite-vue3&ep.readme_path=module-federation-vite-vue3%2Fhost%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodule-federation-vite-vue3%2Fhost&dt=ModuleFederationExamples+module-federation-vite-vue3%2Fhost%2FREADME.md">

--- a/module-federation-vite-vue3/remote/README.md
+++ b/module-federation-vite-vue3/remote/README.md
@@ -44,3 +44,5 @@ npm run build
 ```sh
 npm run lint
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=module-federation-vite-vue3&ep.readme_path=module-federation-vite-vue3%2Fremote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmodule-federation-vite-vue3%2Fremote&dt=ModuleFederationExamples+module-federation-vite-vue3%2Fremote%2FREADME.md">

--- a/multiple-share-scope/README.md
+++ b/multiple-share-scope/README.md
@@ -48,3 +48,5 @@ pnpm start
 pnpm build
 pnpm serve
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=multiple-share-scope&ep.readme_path=multiple-share-scope%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fmultiple-share-scope&dt=ModuleFederationExamples+multiple-share-scope%2FREADME.md">

--- a/native-federation-react/README.md
+++ b/native-federation-react/README.md
@@ -27,3 +27,5 @@ It would be nice if we can use:
 import React from 'react';
 import ReactDOM from 'react-dom';
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=native-federation-react&ep.readme_path=native-federation-react%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnative-federation-react&dt=ModuleFederationExamples+native-federation-react%2FREADME.md">

--- a/native-federation-tests-typescript-plugins/README.md
+++ b/native-federation-tests-typescript-plugins/README.md
@@ -7,3 +7,5 @@ There are 2 modules, in which you can see them in action:
 
 - host
 - remote
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=native-federation-tests-typescript-plugins&ep.readme_path=native-federation-tests-typescript-plugins%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnative-federation-tests-typescript-plugins&dt=ModuleFederationExamples+native-federation-tests-typescript-plugins%2FREADME.md">

--- a/nested-remote/README.md
+++ b/nested-remote/README.md
@@ -13,6 +13,7 @@ Run `pnpm run start`. This will build and serve both `app1`, `app2`, and `app3` 
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
 - [localhost:3003](http://localhost:3003/) (STANDALONE REMOTE)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/Nested">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=nested-remote&ep.readme_path=nested-remote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnested-remote&dt=ModuleFederationExamples+nested-remote%2FREADME.md">

--- a/nextjs-csr/README.md
+++ b/nextjs-csr/README.md
@@ -71,3 +71,5 @@ Useful files in the SSR build.
 The async import middleware is where i keep the async boundary, this is also the only point of reference where React is import into scope.
 
 By doing so, I can ensure that webpack has time to initialize and load anything it might need before attempting to actually require, and render the application.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=nextjs-csr&ep.readme_path=nextjs-csr%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnextjs-csr&dt=ModuleFederationExamples+nextjs-csr%2FREADME.md">

--- a/nextjs-dynamic-ssr/README.md
+++ b/nextjs-dynamic-ssr/README.md
@@ -57,3 +57,5 @@ The sharing limit is due to next not having any async boundary, theres no way to
 I am investigating new methods that may solve the module sharing problem in next.js, however this is a complex problem to solve and requires enormus amounts of knowladge around how webpack and federation work inside the module graph.
 
 ["Best Practices, Rules amd more interesting information here](../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=nextjs-dynamic-ssr&ep.readme_path=nextjs-dynamic-ssr%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnextjs-dynamic-ssr&dt=ModuleFederationExamples+nextjs-dynamic-ssr%2FREADME.md">

--- a/nextjs-host-react-remote/README.md
+++ b/nextjs-host-react-remote/README.md
@@ -38,3 +38,5 @@ Within this application, we've configured the `remotes` object inside of the `Ne
 - Navigate to `localhost:3000` - Two Button Component should be visible, one from remote and another from host app.
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=nextjs-host-react-remote&ep.readme_path=nextjs-host-react-remote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnextjs-host-react-remote&dt=ModuleFederationExamples+nextjs-host-react-remote%2FREADME.md">

--- a/nextjs-host-react-remote/host-app/README.md
+++ b/nextjs-host-react-remote/host-app/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=nextjs-host-react-remote&ep.readme_path=nextjs-host-react-remote%2Fhost-app%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnextjs-host-react-remote%2Fhost-app&dt=ModuleFederationExamples+nextjs-host-react-remote%2Fhost-app%2FREADME.md">

--- a/nextjs-ssr-manifest/README.md
+++ b/nextjs-ssr-manifest/README.md
@@ -59,3 +59,5 @@ To run tests locally, run `pnpm test:e2e` from this example directory.
 To build the apps and run tests in headless mode, run `pnpm e2e:ci`.
 
 ["Best Practices, Rules amd more interesting information here](../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=nextjs-ssr-manifest&ep.readme_path=nextjs-ssr-manifest%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnextjs-ssr-manifest&dt=ModuleFederationExamples+nextjs-ssr-manifest%2FREADME.md">

--- a/nextjs-ssr-react-query/README.md
+++ b/nextjs-ssr-react-query/README.md
@@ -27,3 +27,5 @@ Browse to the following URLs:
 - http://localhost:3002/ (basic federation)
 
 - http://localhost:3003/ (basic federation)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=nextjs-ssr-react-query&ep.readme_path=nextjs-ssr-react-query%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnextjs-ssr-react-query&dt=ModuleFederationExamples+nextjs-ssr-react-query%2FREADME.md">

--- a/nextjs-ssr-react-query/libs/domain/README.md
+++ b/nextjs-ssr-react-query/libs/domain/README.md
@@ -9,3 +9,5 @@ Run `nx build domain` to build the library.
 ## Running unit tests
 
 Run `nx test domain` to execute the unit tests via [Jest](https://jestjs.io).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=nextjs-ssr-react-query&ep.readme_path=nextjs-ssr-react-query%2Flibs%2Fdomain%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnextjs-ssr-react-query%2Flibs%2Fdomain&dt=ModuleFederationExamples+nextjs-ssr-react-query%2Flibs%2Fdomain%2FREADME.md">

--- a/nextjs-ssr/README.md
+++ b/nextjs-ssr/README.md
@@ -57,3 +57,5 @@ The sharing limit is due to next not having any async boundary, theres no way to
 I am investigating new methods that may solve the module sharing problem in next.js, however this is a complex problem to solve and requires enormus amounts of knowladge around how webpack and federation work inside the module graph.
 
 ["Best Practices, Rules amd more interesting information here](../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=nextjs-ssr&ep.readme_path=nextjs-ssr%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fnextjs-ssr&dt=ModuleFederationExamples+nextjs-ssr%2FREADME.md">

--- a/playwright-e2e/README.md
+++ b/playwright-e2e/README.md
@@ -86,3 +86,5 @@ import { BaseMethods } from '../../playwright-e2e/common/base';
 ```
 
 When adding reusable helpers, place them in `playwright-e2e/common/base.ts`.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=playwright-e2e&ep.readme_path=playwright-e2e%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fplaywright-e2e&dt=ModuleFederationExamples+playwright-e2e%2FREADME.md">

--- a/quasar-cli-vue3-webpack-javascript/README.md
+++ b/quasar-cli-vue3-webpack-javascript/README.md
@@ -86,3 +86,5 @@ Import the `ModuleFederationPlugin` and initialise inside `extendWebpack`
 ```
 
 Now you can start using the plugin!
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=quasar-cli-vue3-webpack-javascript&ep.readme_path=quasar-cli-vue3-webpack-javascript%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fquasar-cli-vue3-webpack-javascript&dt=ModuleFederationExamples+quasar-cli-vue3-webpack-javascript%2FREADME.md">

--- a/quasar-cli-vue3-webpack-javascript/app-exposes/README.md
+++ b/quasar-cli-vue3-webpack-javascript/app-exposes/README.md
@@ -41,3 +41,5 @@ quasar build
 ### Customize the configuration
 
 See [Configuring quasar.config.js](https://v2.quasar.dev/quasar-cli-webpack/quasar-config-js).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=quasar-cli-vue3-webpack-javascript&ep.readme_path=quasar-cli-vue3-webpack-javascript%2Fapp-exposes%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fquasar-cli-vue3-webpack-javascript%2Fapp-exposes&dt=ModuleFederationExamples+quasar-cli-vue3-webpack-javascript%2Fapp-exposes%2FREADME.md">

--- a/quasar-cli-vue3-webpack-javascript/app-general/README.md
+++ b/quasar-cli-vue3-webpack-javascript/app-general/README.md
@@ -41,3 +41,5 @@ quasar build
 ### Customize the configuration
 
 See [Configuring quasar.config.js](https://v2.quasar.dev/quasar-cli-webpack/quasar-config-js).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=quasar-cli-vue3-webpack-javascript&ep.readme_path=quasar-cli-vue3-webpack-javascript%2Fapp-general%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fquasar-cli-vue3-webpack-javascript%2Fapp-general&dt=ModuleFederationExamples+quasar-cli-vue3-webpack-javascript%2Fapp-general%2FREADME.md">

--- a/react-16-17-18-ssr/README.md
+++ b/react-16-17-18-ssr/README.md
@@ -17,3 +17,5 @@ Bellow you can see the port mapping:
 - [localhost:3000](http://localhost:3000/) (SHELL)
 - [localhost:3001](http://localhost:3001/) (STANDALONE REMOTE1)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE2)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-16-17-18-ssr&ep.readme_path=react-16-17-18-ssr%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-16-17-18-ssr&dt=ModuleFederationExamples+react-16-17-18-ssr%2FREADME.md">

--- a/react-18-code-splitting/README.md
+++ b/react-18-code-splitting/README.md
@@ -17,3 +17,5 @@ Bellow you can see the port mapping:
 
 - [localhost:3000](http://localhost:3000/) (app1)
 - [localhost:3001](http://localhost:3001/) (app2)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-18-code-splitting&ep.readme_path=react-18-code-splitting%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-18-code-splitting&dt=ModuleFederationExamples+react-18-code-splitting%2FREADME.md">

--- a/react-18-server-2-server/README.md
+++ b/react-18-server-2-server/README.md
@@ -19,3 +19,5 @@ Bellow you can see the port mapping:
 
 - [localhost:3000](http://localhost:3000/) (app1)
 - [localhost:3001](http://localhost:3001/) (app2)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-18-server-2-server&ep.readme_path=react-18-server-2-server%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-18-server-2-server&dt=ModuleFederationExamples+react-18-server-2-server%2FREADME.md">

--- a/react-18-ssr/README.md
+++ b/react-18-ssr/README.md
@@ -19,3 +19,5 @@ Bellow you can see the port mapping:
 - [localhost:3000](http://localhost:3000/) (SHELL)
 - [localhost:3001](http://localhost:3001/) (STANDALONE REMOTE1)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE2)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-18-ssr&ep.readme_path=react-18-ssr%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-18-ssr&dt=ModuleFederationExamples+react-18-ssr%2FREADME.md">

--- a/react-in-vue/README.md
+++ b/react-in-vue/README.md
@@ -24,3 +24,5 @@ This will build and serve both `home` and `layout` on ports `3002` and `3001` re
 - Remote (home, React app): [localhost:3002](http://localhost:3002/)
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-in-vue&ep.readme_path=react-in-vue%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-in-vue&dt=ModuleFederationExamples+react-in-vue%2FREADME.md">

--- a/react-livereload/README.md
+++ b/react-livereload/README.md
@@ -23,3 +23,5 @@ Remote1 is hosted port 3001 and exposes 2 components Heading and Button.
 The exposed components are used in Host.
 
 The project also uses React Router to show that routing logic works just like a normal React app
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-livereload&ep.readme_path=react-livereload%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-livereload&dt=ModuleFederationExamples+react-livereload%2FREADME.md">

--- a/react-manifest-example/README.md
+++ b/react-manifest-example/README.md
@@ -15,3 +15,5 @@ pnpm run start
 Host runs at http://localhost:3000 (live reload only)
 Remote1 runs at http://localhost:3001 (HMR supported)
 Remote2 runs at http://localhost:3002 (HMR supported)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-manifest-example&ep.readme_path=react-manifest-example%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-manifest-example&dt=ModuleFederationExamples+react-manifest-example%2FREADME.md">

--- a/react-manifest-example/host/README.md
+++ b/react-manifest-example/host/README.md
@@ -27,3 +27,5 @@ Preview the production build locally:
 ```bash
 pnpm preview
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-manifest-example&ep.readme_path=react-manifest-example%2Fhost%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-manifest-example%2Fhost&dt=ModuleFederationExamples+react-manifest-example%2Fhost%2FREADME.md">

--- a/react-manifest-example/remote1/README.md
+++ b/react-manifest-example/remote1/README.md
@@ -27,3 +27,5 @@ Preview the production build locally:
 ```bash
 pnpm preview
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-manifest-example&ep.readme_path=react-manifest-example%2Fremote1%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-manifest-example%2Fremote1&dt=ModuleFederationExamples+react-manifest-example%2Fremote1%2FREADME.md">

--- a/react-manifest-example/remote2/README.md
+++ b/react-manifest-example/remote2/README.md
@@ -27,3 +27,5 @@ Preview the production build locally:
 ```bash
 pnpm preview
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-manifest-example&ep.readme_path=react-manifest-example%2Fremote2%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-manifest-example%2Fremote2&dt=ModuleFederationExamples+react-manifest-example%2Fremote2%2FREADME.md">

--- a/react-nextjs/README.md
+++ b/react-nextjs/README.md
@@ -55,3 +55,5 @@ It is a middle-level app, which depends on modules exposed from remote app, for 
 - This type of module federated at folder: `nextjs-host-react-remote`
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-nextjs&ep.readme_path=react-nextjs%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-nextjs&dt=ModuleFederationExamples+react-nextjs%2FREADME.md">

--- a/react-nextjs/nextjs-host-react-remote/README.md
+++ b/react-nextjs/nextjs-host-react-remote/README.md
@@ -52,3 +52,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-nextjs&ep.readme_path=react-nextjs%2Fnextjs-host-react-remote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-nextjs%2Fnextjs-host-react-remote&dt=ModuleFederationExamples+react-nextjs%2Fnextjs-host-react-remote%2FREADME.md">

--- a/react-nextjs/nextjs-host-react-remote/host/README.md
+++ b/react-nextjs/nextjs-host-react-remote/host/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-nextjs&ep.readme_path=react-nextjs%2Fnextjs-host-react-remote%2Fhost%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-nextjs%2Fnextjs-host-react-remote%2Fhost&dt=ModuleFederationExamples+react-nextjs%2Fnextjs-host-react-remote%2Fhost%2FREADME.md">

--- a/react-nextjs/nextjs-host-remote/host/README.md
+++ b/react-nextjs/nextjs-host-remote/host/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-nextjs&ep.readme_path=react-nextjs%2Fnextjs-host-remote%2Fhost%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-nextjs%2Fnextjs-host-remote%2Fhost&dt=ModuleFederationExamples+react-nextjs%2Fnextjs-host-remote%2Fhost%2FREADME.md">

--- a/react-nextjs/nextjs-host-remote/remote/README.md
+++ b/react-nextjs/nextjs-host-remote/remote/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-nextjs&ep.readme_path=react-nextjs%2Fnextjs-host-remote%2Fremote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-nextjs%2Fnextjs-host-remote%2Fremote&dt=ModuleFederationExamples+react-nextjs%2Fnextjs-host-remote%2Fremote%2FREADME.md">

--- a/react-nextjs/react-host-nextjs-remote/remote/README.md
+++ b/react-nextjs/react-host-nextjs-remote/remote/README.md
@@ -32,3 +32,5 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-nextjs&ep.readme_path=react-nextjs%2Freact-host-nextjs-remote%2Fremote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-nextjs%2Freact-host-nextjs-remote%2Fremote&dt=ModuleFederationExamples+react-nextjs%2Freact-host-nextjs-remote%2Fremote%2FREADME.md">

--- a/react-preact-runtime-typescript/README.md
+++ b/react-preact-runtime-typescript/README.md
@@ -11,3 +11,5 @@ Run `pnpm run start`. This will build and serve both `shell` and `remote` on por
 
 - [localhost:3001](http://localhost:3001/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-preact-runtime-typescript&ep.readme_path=react-preact-runtime-typescript%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-preact-runtime-typescript&dt=ModuleFederationExamples+react-preact-runtime-typescript%2FREADME.md">

--- a/react-sharedworker/README.md
+++ b/react-sharedworker/README.md
@@ -22,3 +22,5 @@ yarn start:host
 2. Dynamically import bootstrap file in worker thread
 3. Use promise based dynamic remotes `host/webpack.host-config.js`
 4. Use multiple entry points in webpack config `module/webpack.module-config.js`
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-sharedworker&ep.readme_path=react-sharedworker%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-sharedworker&dt=ModuleFederationExamples+react-sharedworker%2FREADME.md">

--- a/react-storybook/README.md
+++ b/react-storybook/README.md
@@ -11,3 +11,5 @@ Run `pnpm run start`. This will build and serve both `host` and `remote` on port
 
 - [localhost:3000](http://localhost:3000/) (HOST)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-storybook&ep.readme_path=react-storybook%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-storybook&dt=ModuleFederationExamples+react-storybook%2FREADME.md">

--- a/react-webpack-host-vite-remote/README.md
+++ b/react-webpack-host-vite-remote/README.md
@@ -44,3 +44,5 @@ Open `http://localhost:3000` after both services are running to see the host con
 ## License
 
 This project is licensed under the terms of the Apache 2.0 license. See the [LICENSE](LICENSE) file for details.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=react-webpack-host-vite-remote&ep.readme_path=react-webpack-host-vite-remote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Freact-webpack-host-vite-remote&dt=ModuleFederationExamples+react-webpack-host-vite-remote%2FREADME.md">

--- a/redux-reducer-injection/README.md
+++ b/redux-reducer-injection/README.md
@@ -11,6 +11,7 @@ This example shows how you can share your redux store across your remote app and
 2. Browse to localhost:3001
 
 You should see a `Welcome to Host App` and a `button`
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/ReduxReducerInjection">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=redux-reducer-injection&ep.readme_path=redux-reducer-injection%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fredux-reducer-injection&dt=ModuleFederationExamples+redux-reducer-injection%2FREADME.md">

--- a/rsbuild-vue3-vuex/README.md
+++ b/rsbuild-vue3-vuex/README.md
@@ -21,3 +21,5 @@ pnpm run dev
 ## Additional Notes
 
 - Ensure that both the provider and consumer folders have their dependencies installed before running the application.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=rsbuild-vue3-vuex&ep.readme_path=rsbuild-vue3-vuex%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Frsbuild-vue3-vuex&dt=ModuleFederationExamples+rsbuild-vue3-vuex%2FREADME.md">

--- a/rspack-webpack-interop/README.md
+++ b/rspack-webpack-interop/README.md
@@ -239,3 +239,5 @@ curl http://localhost:3005/remoteEntry.js
 - [Webpack Module Federation](https://webpack.js.org/concepts/module-federation/)
 
 [Best Practices, Rules and more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=rspack-webpack-interop&ep.readme_path=rspack-webpack-interop%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Frspack-webpack-interop&dt=ModuleFederationExamples+rspack-webpack-interop%2FREADME.md">

--- a/rspack-webpack-interop/app-04/README.md
+++ b/rspack-webpack-interop/app-04/README.md
@@ -60,3 +60,5 @@ Then, from within your project folder:
 npm run build
 surge public
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=rspack-webpack-interop&ep.readme_path=rspack-webpack-interop%2Fapp-04%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Frspack-webpack-interop%2Fapp-04&dt=ModuleFederationExamples+rspack-webpack-interop%2Fapp-04%2FREADME.md">

--- a/rspack-webpack-offload/README.md
+++ b/rspack-webpack-offload/README.md
@@ -42,3 +42,5 @@ It is a pure host, uses webpack
 after all the commands done, open your browser at `http://localhost:3002`, open the dev-tool's network tab to see resources loading details
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=rspack-webpack-offload&ep.readme_path=rspack-webpack-offload%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Frspack-webpack-offload&dt=ModuleFederationExamples+rspack-webpack-offload%2FREADME.md">

--- a/rspack_hmr/README.md
+++ b/rspack_hmr/README.md
@@ -9,3 +9,5 @@ runtime remotes:
 run `runhost` (localhost:3003) and `app2`
 
 HMR should work fine in both cases!
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=rspack_hmr&ep.readme_path=rspack_hmr%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Frspack_hmr&dt=ModuleFederationExamples+rspack_hmr%2FREADME.md">

--- a/runtime-plugins/README.md
+++ b/runtime-plugins/README.md
@@ -24,3 +24,5 @@ These examples show how runtime plugins move product policy out of Module Federa
 - `single-runtime`: demonstrates single-runtime behavior for host/remote sharing.
 
 Additional core hooks such as `afterLoadShare`, `errorLoadShare`, snapshot hooks, and bridge hooks are available for production plugins, but these examples stay focused on the hooks they exercise directly.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=runtime-plugins&ep.readme_path=runtime-plugins%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fruntime-plugins&dt=ModuleFederationExamples+runtime-plugins%2FREADME.md">

--- a/runtime-plugins/control-sharing/README.md
+++ b/runtime-plugins/control-sharing/README.md
@@ -64,3 +64,5 @@ The runtime plugin (`control-share.ts`) handles:
 - Share scope management
 - Instance tracking and updates
 - Cross-application module sharing rules
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=runtime-plugins&ep.readme_path=runtime-plugins%2Fcontrol-sharing%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fruntime-plugins%2Fcontrol-sharing&dt=ModuleFederationExamples+runtime-plugins%2Fcontrol-sharing%2FREADME.md">

--- a/runtime-plugins/isolate-shared-dependencies/README.md
+++ b/runtime-plugins/isolate-shared-dependencies/README.md
@@ -49,3 +49,5 @@ Run `pnpm run start`. This will build and serve both `app1`, `app2` and `app3` o
 - [localhost:3003](http://localhost:3003/)
 
 Not implemented yet
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=runtime-plugins&ep.readme_path=runtime-plugins%2Fisolate-shared-dependencies%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fruntime-plugins%2Fisolate-shared-dependencies&dt=ModuleFederationExamples+runtime-plugins%2Fisolate-shared-dependencies%2FREADME.md">

--- a/runtime-plugins/multiple-react-versions/README.md
+++ b/runtime-plugins/multiple-react-versions/README.md
@@ -29,3 +29,5 @@ To run the demo, follow these steps:
 4. Open [localhost:3002](http://localhost:3002/) to view `app2` (STANDALONE REMOTE)
 
 This example showcases the power of Module Federation in enabling the integration of different versions of React, allowing for incremental upgrades and the coexistence of legacy and modern components in a single application.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=runtime-plugins&ep.readme_path=runtime-plugins%2Fmultiple-react-versions%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fruntime-plugins%2Fmultiple-react-versions&dt=ModuleFederationExamples+runtime-plugins%2Fmultiple-react-versions%2FREADME.md">

--- a/runtime-plugins/offline-remote/README.md
+++ b/runtime-plugins/offline-remote/README.md
@@ -2,3 +2,5 @@
 
 This demo boots only app1, app2 remains offline.
 Loading localhost:3001 will render a error message from the runtime plugin as a react module when the container if offline.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=runtime-plugins&ep.readme_path=runtime-plugins%2Foffline-remote%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fruntime-plugins%2Foffline-remote&dt=ModuleFederationExamples+runtime-plugins%2Foffline-remote%2FREADME.md">

--- a/runtime-plugins/remote-control/README.md
+++ b/runtime-plugins/remote-control/README.md
@@ -30,3 +30,5 @@ To give the application a spin, run `pnpm start`. This command will build and se
 - `pnpm e2e:ci` builds the applications and executes the suite in headless mode, the same flow used in CI.
 
 Playwright stores traces, screenshots, and videos for failing specs inside `playwright-report` when run in CI mode.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=runtime-plugins&ep.readme_path=runtime-plugins%2Fremote-control%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fruntime-plugins%2Fremote-control&dt=ModuleFederationExamples+runtime-plugins%2Fremote-control%2FREADME.md">

--- a/runtime-plugins/remote-router/README.md
+++ b/runtime-plugins/remote-router/README.md
@@ -21,3 +21,5 @@ pnpm --filter remote-router e2e:ci
 ```
 
 `e2e:ci` builds the host so CI exercises the runtime plugin instead of passing through a placeholder script.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=runtime-plugins&ep.readme_path=runtime-plugins%2Fremote-router%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fruntime-plugins%2Fremote-router&dt=ModuleFederationExamples+runtime-plugins%2Fremote-router%2FREADME.md">

--- a/runtime-plugins/remote-router/remotes-monorepo/README.md
+++ b/runtime-plugins/remote-router/remotes-monorepo/README.md
@@ -55,3 +55,5 @@ Nx comes with local caching already built-in (check your `nx.json`). On CI you m
 - [Join the community](https://nx.dev/community)
 - [Subscribe to the Nx Youtube Channel](https://www.youtube.com/@nxdevtools)
 - [Follow us on Twitter](https://twitter.com/nxdevtools)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=runtime-plugins&ep.readme_path=runtime-plugins%2Fremote-router%2Fremotes-monorepo%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fruntime-plugins%2Fremote-router%2Fremotes-monorepo&dt=ModuleFederationExamples+runtime-plugins%2Fremote-router%2Fremotes-monorepo%2FREADME.md">

--- a/runtime-plugins/single-runtime/README.md
+++ b/runtime-plugins/single-runtime/README.md
@@ -55,3 +55,5 @@ Both apps share:
 - Lodash (version matching)
 
 The single runtime plugin ensures these shared dependencies maintain their singleton status by preventing duplicate runtime loading from the same build. Also prevents collisions caused by loading 2 runtimes from the same build at once
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=runtime-plugins&ep.readme_path=runtime-plugins%2Fsingle-runtime%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fruntime-plugins%2Fsingle-runtime&dt=ModuleFederationExamples+runtime-plugins%2Fsingle-runtime%2FREADME.md">

--- a/rust-wasm/README.md
+++ b/rust-wasm/README.md
@@ -132,3 +132,5 @@ This demo is built upon many OSS projects including:
 - [wasm-pack](https://rustwasm.github.io/wasm-pack/installer/) -> Webpack loader for compiling Rust to Wasm
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=rust-wasm&ep.readme_path=rust-wasm%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Frust-wasm&dt=ModuleFederationExamples+rust-wasm%2FREADME.md">

--- a/self-healing/README.md
+++ b/self-healing/README.md
@@ -30,6 +30,7 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 - REMOTE: [localhost:3002](http://localhost:3002/)
 
 Notice that the button in both apps are the same even though the host app didn't provide `styled-components` as a dependency. If you open DevTools and checkout the "Network" tab you can see 2 requests were made to `app2`; the remote `<Button />` component and the missing `styled-components` vendor code.
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/SelfHealing">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=self-healing&ep.readme_path=self-healing%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fself-healing&dt=ModuleFederationExamples+self-healing%2FREADME.md">

--- a/server-side-render-only/README.md
+++ b/server-side-render-only/README.md
@@ -14,3 +14,5 @@ http://localhost:3000/ - Host Server
 http://localhost:3001/ - Remote Server
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=server-side-render-only&ep.readme_path=server-side-render-only%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fserver-side-render-only&dt=ModuleFederationExamples+server-side-render-only%2FREADME.md">

--- a/server-side-rendering/README.md
+++ b/server-side-rendering/README.md
@@ -21,3 +21,5 @@ This will build the packages and and serve them on ports 3000, 3001 and 3002 res
 - [localhost:3000](http://localhost:3000/) (SHELL)
 - [localhost:3001](http://localhost:3001/) (STANDALONE REMOTE1)
 - [localhost:3002](http://localhost:3002/) (STANDALONE REMOTE2)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=server-side-rendering&ep.readme_path=server-side-rendering%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fserver-side-rendering&dt=ModuleFederationExamples+server-side-rendering%2FREADME.md">

--- a/shared-context/README.md
+++ b/shared-context/README.md
@@ -12,6 +12,7 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 
 - [localhost:3001](http://localhost:3001/)
 - [localhost:3002](http://localhost:3002/)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/SharedContext">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=shared-context&ep.readme_path=shared-context%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fshared-context&dt=ModuleFederationExamples+shared-context%2FREADME.md">

--- a/shared-directory/README.md
+++ b/shared-directory/README.md
@@ -19,3 +19,5 @@ http://localhost:5176/
 Open your browser at http://localhost:5172/ to see the amazing result
 
 ![alt text](image.png)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=shared-directory&ep.readme_path=shared-directory%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fshared-directory&dt=ModuleFederationExamples+shared-directory%2FREADME.md">

--- a/shared-directory/rust-host/README.md
+++ b/shared-directory/rust-host/README.md
@@ -27,3 +27,5 @@ Preview the production build locally:
 ```bash
 pnpm preview
 ```
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=shared-directory&ep.readme_path=shared-directory%2Frust-host%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fshared-directory%2Frust-host&dt=ModuleFederationExamples+shared-directory%2Frust-host%2FREADME.md">

--- a/shared-routes2/README.md
+++ b/shared-routes2/README.md
@@ -12,6 +12,7 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 
 - [localhost:3001](http://localhost:3001/)
 - [localhost:3002](http://localhost:3002/)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/SharedRoutes2">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=shared-routes2&ep.readme_path=shared-routes2%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fshared-routes2&dt=ModuleFederationExamples+shared-routes2%2FREADME.md">

--- a/shared-routing/README.md
+++ b/shared-routing/README.md
@@ -20,6 +20,6 @@ To run the application, run `pnpm run start`. This will build all the apps `shel
 
 You will notice that each of the above URLs will look exactly same. For more details [Watch this YouTube video](https://www.youtube.com/watch?v=-LNcpralkjM)
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/AppShellSharedRoutes">
-
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=shared-routing&ep.readme_path=shared-routing%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fshared-routing&dt=ModuleFederationExamples+shared-routing%2FREADME.md">

--- a/shared-store-cross-framework/README.md
+++ b/shared-store-cross-framework/README.md
@@ -18,6 +18,7 @@ Run `yarn` to install the dependencies.\
 Run `pnpm run start` to build and serve the shell, shared-store, react-counter and vue-counter at once.
 
 The shell will be accessible on [localhost:3001](http://localhost:3001/)
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/SharedStoreCrossFramework">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=shared-store-cross-framework&ep.readme_path=shared-store-cross-framework%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fshared-store-cross-framework&dt=ModuleFederationExamples+shared-store-cross-framework%2FREADME.md">

--- a/simple-node/README.md
+++ b/simple-node/README.md
@@ -11,3 +11,5 @@ This repository contains a basic example of how to use Node Federation. It demon
    `pnpm run start`
 
 After following these steps, your Node Federation example should be up and running.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=simple-node&ep.readme_path=simple-node%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fsimple-node&dt=ModuleFederationExamples+simple-node%2FREADME.md">

--- a/styled-components/README.md
+++ b/styled-components/README.md
@@ -27,3 +27,5 @@ Bellow you can see the port mapping:
 
 - [localhost:3000](http://localhost:3000/) (app1)
 - [localhost:3001](http://localhost:3001/) (app2)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=styled-components&ep.readme_path=styled-components%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fstyled-components&dt=ModuleFederationExamples+styled-components%2FREADME.md">

--- a/third-party-scripts/README.md
+++ b/third-party-scripts/README.md
@@ -12,6 +12,6 @@ This will build and serve `app1` on port 3001
 
 - [localhost:3001](http://localhost:3001/) (HOST)
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/BasicRemoteHost">
-
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=third-party-scripts&ep.readme_path=third-party-scripts%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fthird-party-scripts&dt=ModuleFederationExamples+third-party-scripts%2FREADME.md">

--- a/typescript-monorepo/README.md
+++ b/typescript-monorepo/README.md
@@ -10,6 +10,7 @@ This will build and serve both `app1` and `app2` on ports 3001 and 3002 respecti
 
 - [localhost:3001](http://localhost:3001/)
 - [localhost:3002](http://localhost:3002/)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/TypeScriptProjectReferences">
 
 ["Best Practices, Rules amd more interesting information here](../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=typescript-monorepo&ep.readme_path=typescript-monorepo%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ftypescript-monorepo&dt=ModuleFederationExamples+typescript-monorepo%2FREADME.md">

--- a/typescript-project-references/README.md
+++ b/typescript-project-references/README.md
@@ -10,6 +10,7 @@ This will build and serve both `app1` and `app2` on ports 3001 and 3002 respecti
 
 - [localhost:3001](http://localhost:3001/)
 - [localhost:3002](http://localhost:3002/)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/TypeScriptProjectReferences">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=typescript-project-references&ep.readme_path=typescript-project-references%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ftypescript-project-references&dt=ModuleFederationExamples+typescript-project-references%2FREADME.md">

--- a/typescript-react-fallback/README.md
+++ b/typescript-react-fallback/README.md
@@ -10,6 +10,7 @@ This will build and serve both `app1` and `app2` on ports 3001 and 3002 respecti
 
 - [localhost:3001](http://localhost:3001/)
 - [localhost:3002](http://localhost:3002/)
-  <img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/TypeScriptProjectReferences">
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=typescript-react-fallback&ep.readme_path=typescript-react-fallback%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ftypescript-react-fallback&dt=ModuleFederationExamples+typescript-react-fallback%2FREADME.md">

--- a/typescript-react-monorepo-test/README.md
+++ b/typescript-react-monorepo-test/README.md
@@ -31,3 +31,5 @@ This is achieved using webpack's `resolve.alias` by telling it how to resolve re
 # Tip
 
 - Monorepo is requirement for jest to run.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=typescript-react-monorepo-test&ep.readme_path=typescript-react-monorepo-test%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ftypescript-react-monorepo-test&dt=ModuleFederationExamples+typescript-react-monorepo-test%2FREADME.md">

--- a/typescript-react-monorepo/README.md
+++ b/typescript-react-monorepo/README.md
@@ -26,3 +26,5 @@ Run `pnpm run start` in root folder. This will build and serve both `host` and `
 
 - Monorepo is used for ease of use. But there is no requirement to use it.
 - This project demonstrates the functionality of @module-federation/typescript. To read more, you can refer to the documentation of this package.
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=typescript-react-monorepo&ep.readme_path=typescript-react-monorepo%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ftypescript-react-monorepo&dt=ModuleFederationExamples+typescript-react-monorepo%2FREADME.md">

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -15,6 +15,6 @@ Run `pnpm run start`. This will build and serve both `app1` and `app2` on ports 
 - [localhost:3001](http://localhost:3001/)
 - [localhost:3002](http://localhost:3002/)
 
-<img src="https://ssl.google-analytics.com/collect?v=1&t=event&ec=email&ea=open&t=event&tid=UA-120967034-1&z=1589682154&cid=ae045149-9d17-0367-bbb0-11c41d92b411&dt=ModuleFederationExamples&dp=/email/TypeScript">
-
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=typescript&ep.readme_path=typescript%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Ftypescript&dt=ModuleFederationExamples+typescript%2FREADME.md">

--- a/umd-federation/README.md
+++ b/umd-federation/README.md
@@ -24,3 +24,5 @@ Create lerna.json if you are in online example
 "npmClient": "yarn",
 "useWorkspaces": true
 }
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=umd-federation&ep.readme_path=umd-federation%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fumd-federation&dt=ModuleFederationExamples+umd-federation%2FREADME.md">

--- a/unit-test/README.md
+++ b/unit-test/README.md
@@ -19,3 +19,5 @@ To run tests in interactive mode, run `npm run cypress:debug` from the root dire
 To build app and run test in headless mode, run `yarn e2e:ci`. It will build app and run tests for this workspace in headless mode. If tets failed cypress will create `cypress` directory in sample root folder with screenshots and videos.
 
 ["Best Practices, Rules amd more interesting information here](../../cypress/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=unit-test&ep.readme_path=unit-test%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Funit-test&dt=ModuleFederationExamples+unit-test%2FREADME.md">

--- a/vue-cli/consumer/README.md
+++ b/vue-cli/consumer/README.md
@@ -27,3 +27,5 @@ yarn lint
 ### Customize configuration
 
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=vue-cli&ep.readme_path=vue-cli%2Fconsumer%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fvue-cli%2Fconsumer&dt=ModuleFederationExamples+vue-cli%2Fconsumer%2FREADME.md">

--- a/vue-cli/core/README.md
+++ b/vue-cli/core/README.md
@@ -27,3 +27,5 @@ yarn lint
 ### Customize configuration
 
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=vue-cli&ep.readme_path=vue-cli%2Fcore%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fvue-cli%2Fcore&dt=ModuleFederationExamples+vue-cli%2Fcore%2FREADME.md">

--- a/vue2-in-vue3/README.md
+++ b/vue2-in-vue3/README.md
@@ -10,3 +10,5 @@ Run `pnpm run start` . This will build and serve both `vue3` and `vue2` on ports
 - REMOTE (vue2): [localhost:3001](http://localhost:3001/)
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=vue2-in-vue3&ep.readme_path=vue2-in-vue3%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fvue2-in-vue3&dt=ModuleFederationExamples+vue2-in-vue3%2FREADME.md">

--- a/vue3-cli-demo/README.md
+++ b/vue3-cli-demo/README.md
@@ -26,3 +26,5 @@ After that open
 http://localhost:8081
 
 More information [./app-general/README.md](./app-general/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=vue3-cli-demo&ep.readme_path=vue3-cli-demo%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fvue3-cli-demo&dt=ModuleFederationExamples+vue3-cli-demo%2FREADME.md">

--- a/vue3-cli-demo/app-exposes/README.md
+++ b/vue3-cli-demo/app-exposes/README.md
@@ -39,3 +39,5 @@ npm run lint
 ### Customize configuration
 
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=vue3-cli-demo&ep.readme_path=vue3-cli-demo%2Fapp-exposes%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fvue3-cli-demo%2Fapp-exposes&dt=ModuleFederationExamples+vue3-cli-demo%2Fapp-exposes%2FREADME.md">

--- a/vue3-cli-demo/app-general/README.md
+++ b/vue3-cli-demo/app-general/README.md
@@ -33,3 +33,5 @@ npm run lint
 ### Customize configuration
 
 See [Configuration Reference](https://cli.vuejs.org/config/).
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=vue3-cli-demo&ep.readme_path=vue3-cli-demo%2Fapp-general%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fvue3-cli-demo%2Fapp-general&dt=ModuleFederationExamples+vue3-cli-demo%2Fapp-general%2FREADME.md">

--- a/vue3-demo/README.md
+++ b/vue3-demo/README.md
@@ -12,3 +12,5 @@ Run `pnpm run start` . This will build and serve both `home` and `layout` on por
 - REMOTE (home): [localhost:3002](http://localhost:3002/)
 
 ["Best Practices, Rules amd more interesting information here](../../playwright-e2e/README.md)
+
+<img width="0" height="0" alt="" src="https://www.google-analytics.com/g/collect?v=2&tid=G-DRPXW0EEVT&cid=ae045149-9d17-0367-bbb0-11c41d92b411&en=readme_view&ep.repository=module-federation-examples&ep.example=vue3-demo&ep.readme_path=vue3-demo%2FREADME.md&dl=https%3A%2F%2Fgithub.com%2Fmodule-federation%2Fmodule-federation-examples%2Ftree%2Fmaster%2Fvue3-demo&dt=ModuleFederationExamples+vue3-demo%2FREADME.md">


### PR DESCRIPTION
## Summary
- add GA4 README tracking pixels using measurement ID G-DRPXW0EEVT to every README.md in the repo
- replace the existing stale Universal Analytics README pixels where they were present
- include both ep.example and ep.readme_path so Analytics can report by top-level example family and exact README path

## Validation
- checked all README.md files: readmeCount=152, issueCount=0
- every tag has tid=G-DRPXW0EEVT, en=readme_view, ep.repository=module-federation-examples, ep.example, and ep.readme_path
- no old ssl.google-analytics.com/collect, UA-120967034-1, ga-beacon, or google-analytics.com/collect Markdown pixels remain
- git diff --check